### PR TITLE
[#8] Avoid closing non-transactional Producer after a couple of usages

### DIFF
--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactory.java
@@ -197,7 +197,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
 
     private abstract static class ProducerDecorator<K, V> implements Producer<K, V> {
 
-        final Producer<K, V> delegate;
+        private final Producer<K, V> delegate;
 
         ProducerDecorator(Producer<K, V> delegate) {
             this.delegate = delegate;
@@ -306,10 +306,12 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
 
         @Override
         public void close() {
+            // Do nothing
         }
 
         @Override
         public void close(long timeout, TimeUnit unit) {
+            // Do nothing
         }
     }
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryTests.java
@@ -117,9 +117,10 @@ public class DefaultProducerFactoryTests {
         List<Producer<String, String>> producers = new ArrayList<>();
         List<Future<RecordMetadata>> results = new ArrayList<>();
         String topic = "testSendingMessagesUsingMultipleProducers";
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 12; i++) {
             Producer<String, String> producer = pf.createProducer();
             results.add(send(producer, topic, "foo" + i));
+            producer.close();
             producers.add(producer);
         }
         assertOffsets(results);


### PR DESCRIPTION
This pull request resolves #8