### PR TITLE
Support of configurable event processors mode to be used for Kafka message publication.

### DIFF
--- a/kafka-axon-example/README.md
+++ b/kafka-axon-example/README.md
@@ -1,0 +1,33 @@
+# Kafka Axon Springboot Example
+
+This is an example SpringBoot application using the Kafka Axon extension. It configures a simple 
+Kafka message publishing using Kafka infrastructure run locally. 
+
+## How to run
+
+### Preparation
+
+You will need `docker` and `docker-compose` to run this example.
+Please run 
+
+``` 
+docker-compose -f ./kafka-axon-example/docker-compose.yaml up
+```
+
+This will start Kafka, Zookeeper, Kafka Rest and Kafka Rest UI (available then on http://localhost:8000/)
+
+Now build the application by running
+
+``` 
+mvn clean package -f ./kafka-axon-example 
+``` 
+
+### Running example application
+ 
+You can start the application by running `java -jar ./kafka-axon-example/target/axon-kafka-example.jar`.
+
+The application runs in two different modes demonstrating publishing of events to Kafka in 
+subscribing or tracking modes. To activate these modes, please use Spring profiles by providing a command
+line parameter `--spring.profiles.active=subscribing` and `--spring.profiles.active=tracking` respectively.   
+
+ 

--- a/kafka-axon-example/README.md
+++ b/kafka-axon-example/README.md
@@ -14,7 +14,7 @@ Please run
 docker-compose -f ./kafka-axon-example/docker-compose.yaml up
 ```
 
-This will start Kafka, Zookeeper, Kafka Rest and Kafka Rest UI (available then on http://localhost:8000/)
+This will start Kafka, Zookeeper, Kafka Rest and Kafka Rest UI (available then on [http://localhost:8000/](http://localhost:8000/))
 
 Now build the application by running
 
@@ -29,5 +29,3 @@ You can start the application by running `java -jar ./kafka-axon-example/target/
 The application runs in two different modes demonstrating publishing of events to Kafka in 
 subscribing or tracking modes. To activate these modes, please use Spring profiles by providing a command
 line parameter `--spring.profiles.active=subscribing` and `--spring.profiles.active=tracking` respectively.   
-
- 

--- a/kafka-axon-example/README.md
+++ b/kafka-axon-example/README.md
@@ -10,7 +10,7 @@ Kafka message publishing using Kafka infrastructure run locally.
 You will need `docker` and `docker-compose` to run this example.
 Please run 
 
-``` 
+```bash 
 docker-compose -f ./kafka-axon-example/docker-compose.yaml up
 ```
 
@@ -18,7 +18,7 @@ This will start Kafka, Zookeeper, Kafka Rest and Kafka Rest UI (available then o
 
 Now build the application by running
 
-``` 
+```bash
 mvn clean package -f ./kafka-axon-example 
 ``` 
 

--- a/kafka-axon-example/docker-compose.yaml
+++ b/kafka-axon-example/docker-compose.yaml
@@ -1,0 +1,67 @@
+version: "3.5"
+services:
+
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - 2181:2181
+    networks:
+      - network1
+
+  kafka:
+    image: wurstmeister/kafka
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_PORT: 9092
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_LISTENERS: "PLAINTEXT://:9092"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+    ports:
+      - 9092:9092
+    networks:
+      - network1
+
+  kafka-rest:
+    image: nodefluent/kafka-rest
+    ports:
+      - 8083:8083
+    links:
+      - kafka
+      - zookeeper
+    depends_on:
+      - kafka
+      - zookeeper
+    environment:
+      DEBUG: "*"
+      KAFKA_REST_DEBUG: "all"
+      KAFKA_REST_HTTP_PORT: 8083
+      KAFKA_REST_CONSUMER_METADATA_BROKER_LIST: "kafka:9092"
+      KAFKA_REST_PRODUCER_METADATA_BROKER_LIST: "kafka:9092"
+    networks:
+      - network1
+
+  kafka-rest-ui:
+    image: nodefluent/kafka-rest-ui
+    ports:
+      - 8000:8000
+    links:
+      - kafka-rest
+    depends_on:
+      - kafka-rest
+    environment:
+      DEBUG: "*"
+      REACT_APP_KAFKA_REST_URL: "http://kafka-rest:8083/"
+      REACT_APP_TIMEOUT: "3000"
+      PROXY: "yes"
+      BASIC_AUTH_USER: "admin"
+      BASIC_AUTH_PASSWORD: "admin"
+    networks:
+      - network1
+
+networks:
+  network1:
+    name: kafka-local

--- a/kafka-axon-example/pom.xml
+++ b/kafka-axon-example/pom.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2018. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.kafka</groupId>
+        <artifactId>axon-kafka-parent</artifactId>
+        <version>4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>axon-kafka-example</artifactId>
+    <version>4.0-SNAPSHOT</version>
+
+    <name>Axon Framework Kafka Extension - Spring Boot Example</name>
+    <description>Example module for the Kafka Extension of Axon Framework</description>
+
+    <properties>
+        <kotlin.version>1.3.50</kotlin.version>
+        <kotlin-logging.version>1.6.22</kotlin-logging.version>
+        <spring-kafka.version>2.2.4.RELEASE</spring-kafka.version>
+        <jackson.version>2.9.9</jackson.version>
+        <apache.kafka.version>2.3.0</apache.kafka.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>${axon.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.axonframework</groupId>
+                    <artifactId>axon-server-connector</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework.extensions.kafka</groupId>
+            <artifactId>axon-kafka-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>${spring-kafka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging</artifactId>
+            <version>${kotlin-logging.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                        <plugin>jpa</plugin>
+                        <plugin>no-arg</plugin>
+                        <plugin>all-open</plugin>
+                    </compilerPlugins>
+                    <pluginOptions>
+                        <option>all-open:annotation=org.axonframework.spring.stereotype.Aggregate</option>
+                    </pluginOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-noarg</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+                <executions>
+                    <!-- Replacing default-compile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <!-- Replacing default-testCompile as it is treated specially by maven -->
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extension.kafka.example
+
+import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
+import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine
+import org.axonframework.extensions.kafka.KafkaProperties
+import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode
+import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory
+import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.scheduling.annotation.EnableScheduling
+
+
+fun main(args: Array<String>) {
+    SpringApplication.run(KafkaAxonExampleApplication::class.java, *args)
+}
+
+@SpringBootApplication
+@EnableScheduling
+class KafkaAxonExampleApplication {
+
+    @Bean
+    fun eventStore() = EmbeddedEventStore.builder().storageEngine(InMemoryEventStorageEngine()).build()
+
+    @Bean
+    fun tokenStore() = InMemoryTokenStore()
+
+    @Bean
+    fun producerFactory(kafkaProperties: KafkaProperties): ProducerFactory<String, ByteArray>? {
+        return DefaultProducerFactory.builder<String, ByteArray>()
+                .configuration(kafkaProperties.buildProducerProperties())
+                .producerCacheSize(10_000)
+                .confirmationMode(ConfirmationMode.WAIT_FOR_ACK)
+                .build()
+    }
+
+}

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -41,12 +41,21 @@ fun main(args: Array<String>) {
 @EnableScheduling
 class KafkaAxonExampleApplication {
 
+    /**
+     * Configures to use in-memory embedded event store.
+     */
     @Bean
     fun eventStore() = EmbeddedEventStore.builder().storageEngine(InMemoryEventStorageEngine()).build()
 
+    /**
+     * Configures to us in-memory token store.
+     */
     @Bean
     fun tokenStore() = InMemoryTokenStore()
 
+    /**
+     * Creates a Kafka producer factory, using the Kakfa properties configured in resources/application.yml
+     */
     @Bean
     fun producerFactory(kafkaProperties: KafkaProperties): ProducerFactory<String, ByteArray>? {
         return DefaultProducerFactory.builder<String, ByteArray>()

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -27,11 +27,16 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
 
-
+/**
+ * Starting point.
+ */
 fun main(args: Array<String>) {
     SpringApplication.run(KafkaAxonExampleApplication::class.java, *args)
 }
 
+/**
+ * Main application class.
+ */
 @SpringBootApplication
 @EnableScheduling
 class KafkaAxonExampleApplication {

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Commands.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Commands.kt
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.axonframework.extension.kafka.example.api
 
 import org.axonframework.modelling.command.TargetAggregateIdentifier
 import javax.validation.constraints.Min
 
+/**
+ * Create account.
+ */
 data class CreateBankAccountCommand(
         @TargetAggregateIdentifier
         val bankAccountId: String,
@@ -25,18 +29,27 @@ data class CreateBankAccountCommand(
         val overdraftLimit: Long
 )
 
+/**
+ * Deposit money.
+ */
 data class DepositMoneyCommand(
         @TargetAggregateIdentifier
         val bankAccountId: String,
         val amountOfMoney: Long
 )
 
+/**
+ * Withdraw money.
+ */
 data class WithdrawMoneyCommand(
         @TargetAggregateIdentifier
         val bankAccountId: String,
         val amountOfMoney: Long
 )
 
+/**
+ * Return money if transfer is not possible.
+ */
 data class ReturnMoneyOfFailedBankTransferCommand(
         @TargetAggregateIdentifier
         val bankAccountId: String,

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Commands.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Commands.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extension.kafka.example.api
+
+import org.axonframework.modelling.command.TargetAggregateIdentifier
+import javax.validation.constraints.Min
+
+data class CreateBankAccountCommand(
+        @TargetAggregateIdentifier
+        val bankAccountId: String,
+        @Min(value = 0, message = "Overdraft limit must not be less than zero")
+        val overdraftLimit: Long
+)
+
+data class DepositMoneyCommand(
+        @TargetAggregateIdentifier
+        val bankAccountId: String,
+        val amountOfMoney: Long
+)
+
+data class WithdrawMoneyCommand(
+        @TargetAggregateIdentifier
+        val bankAccountId: String,
+        val amountOfMoney: Long
+)
+
+data class ReturnMoneyOfFailedBankTransferCommand(
+        @TargetAggregateIdentifier
+        val bankAccountId: String,
+        val amount: Long
+)

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Events.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Events.kt
@@ -13,28 +13,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.axonframework.extension.kafka.example.api
 
+/**
+ * Account created.
+ */
 data class BankAccountCreatedEvent(
         val id: String,
         val overdraftLimit: Long
 )
 
+/**
+ * Collecting event for increasing amount.
+ */
 sealed class MoneyAddedEvent(
         open val bankAccountId: String,
         open val amount: Long
 )
 
+/**
+ * Money deposited.
+ */
 data class MoneyDepositedEvent(override val bankAccountId: String, override val amount: Long) : MoneyAddedEvent(bankAccountId, amount)
+
+/**
+ * Money returned.
+ */
 data class MoneyOfFailedBankTransferReturnedEvent(override val bankAccountId: String, override val amount: Long) : MoneyAddedEvent(bankAccountId, amount)
+
+/**
+ * Money received via transfer.
+ */
 data class DestinationBankAccountCreditedEvent(override val bankAccountId: String, override val amount: Long, val bankTransferId: String) : MoneyAddedEvent(bankAccountId, amount)
 
+/**
+ * Collecting event for decreasing amount.
+ */
 sealed class MoneySubtractedEvent(
         open val bankAccountId: String,
         open val amount: Long
 )
 
+/**
+ * Money withdrawn.
+ */
 data class MoneyWithdrawnEvent(override val bankAccountId: String, override val amount: Long) : MoneySubtractedEvent(bankAccountId, amount)
+
+/**
+ * Money transferred.
+ */
 data class SourceBankAccountDebitedEvent(override val bankAccountId: String, override val amount: Long, val bankTransferId: String) : MoneySubtractedEvent(bankAccountId, amount)
 
+/**
+ * Money transfer rejected.
+ */
 data class SourceBankAccountDebitRejectedEvent(val bankTransferId: String)

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Events.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/api/Events.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extension.kafka.example.api
+
+data class BankAccountCreatedEvent(
+        val id: String,
+        val overdraftLimit: Long
+)
+
+sealed class MoneyAddedEvent(
+        open val bankAccountId: String,
+        open val amount: Long
+)
+
+data class MoneyDepositedEvent(override val bankAccountId: String, override val amount: Long) : MoneyAddedEvent(bankAccountId, amount)
+data class MoneyOfFailedBankTransferReturnedEvent(override val bankAccountId: String, override val amount: Long) : MoneyAddedEvent(bankAccountId, amount)
+data class DestinationBankAccountCreditedEvent(override val bankAccountId: String, override val amount: Long, val bankTransferId: String) : MoneyAddedEvent(bankAccountId, amount)
+
+sealed class MoneySubtractedEvent(
+        open val bankAccountId: String,
+        open val amount: Long
+)
+
+data class MoneyWithdrawnEvent(override val bankAccountId: String, override val amount: Long) : MoneySubtractedEvent(bankAccountId, amount)
+data class SourceBankAccountDebitedEvent(override val bankAccountId: String, override val amount: Long, val bankTransferId: String) : MoneySubtractedEvent(bankAccountId, amount)
+
+data class SourceBankAccountDebitRejectedEvent(val bankTransferId: String)

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/client/BankClient.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/client/BankClient.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extension.kafka.example.client
+
+import org.axonframework.commandhandling.gateway.CommandGateway
+import org.axonframework.extension.kafka.example.api.CreateBankAccountCommand
+import org.axonframework.extension.kafka.example.api.DepositMoneyCommand
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.concurrent.CompletableFuture
+
+@Component
+class BankClient(private val commandGateway: CommandGateway) {
+
+    val accountId = UUID.randomUUID().toString()
+    var amount = 100
+
+    @Scheduled(initialDelay = 5_000, fixedDelay = 1000_000_000)
+    fun createAccount() {
+        commandGateway.send<CompletableFuture<String>>(CreateBankAccountCommand(bankAccountId = accountId, overdraftLimit = 1000))
+    }
+
+    @Scheduled(initialDelay = 10_000, fixedDelay = 20_000)
+    fun deposit() {
+        commandGateway.send<CompletableFuture<String>>(DepositMoneyCommand(bankAccountId = accountId, amountOfMoney = amount.toLong()))
+        amount = amount.inc()
+    }
+}

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/client/BankClient.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/client/BankClient.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.axonframework.extension.kafka.example.client
 
 import org.axonframework.commandhandling.gateway.CommandGateway
@@ -23,6 +24,9 @@ import org.springframework.stereotype.Component
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
+/**
+ * Bank client sending scheduled commands.
+ */
 @Component
 class BankClient(private val commandGateway: CommandGateway) {
 

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/client/BankClient.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/client/BankClient.kt
@@ -30,14 +30,20 @@ import java.util.concurrent.CompletableFuture
 @Component
 class BankClient(private val commandGateway: CommandGateway) {
 
-    val accountId = UUID.randomUUID().toString()
-    var amount = 100
+    private val accountId = UUID.randomUUID().toString()
+    private var amount = 100
 
+    /**
+     * Creates account once.
+     */
     @Scheduled(initialDelay = 5_000, fixedDelay = 1000_000_000)
     fun createAccount() {
         commandGateway.send<CompletableFuture<String>>(CreateBankAccountCommand(bankAccountId = accountId, overdraftLimit = 1000))
     }
 
+    /**
+     * Deposit some money every 20 seconds.
+     */
     @Scheduled(initialDelay = 10_000, fixedDelay = 20_000)
     fun deposit() {
         commandGateway.send<CompletableFuture<String>>(DepositMoneyCommand(bankAccountId = accountId, amountOfMoney = amount.toLong()))

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/core/BankAccount.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/core/BankAccount.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.axonframework.extension.kafka.example.core
 
 import org.axonframework.commandhandling.CommandHandler
@@ -22,6 +23,9 @@ import org.axonframework.modelling.command.AggregateIdentifier
 import org.axonframework.modelling.command.AggregateLifecycle.apply
 import org.axonframework.spring.stereotype.Aggregate
 
+/**
+ * Represent account.
+ */
 @Suppress("unused")
 @Aggregate
 class BankAccount() {
@@ -33,7 +37,7 @@ class BankAccount() {
 
 
     @CommandHandler
-    constructor(command: CreateBankAccountCommand): this() {
+    constructor(command: CreateBankAccountCommand) : this() {
         apply(BankAccountCreatedEvent(command.bankAccountId, command.overdraftLimit))
     }
 

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/core/BankAccount.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/core/BankAccount.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extension.kafka.example.core
+
+import org.axonframework.commandhandling.CommandHandler
+import org.axonframework.eventsourcing.EventSourcingHandler
+import org.axonframework.extension.kafka.example.api.*
+import org.axonframework.modelling.command.AggregateIdentifier
+import org.axonframework.modelling.command.AggregateLifecycle.apply
+import org.axonframework.spring.stereotype.Aggregate
+
+@Suppress("unused")
+@Aggregate
+class BankAccount() {
+
+    @AggregateIdentifier
+    private lateinit var id: String
+    private var overdraftLimit: Long = 0
+    private var balanceInCents: Long = 0
+
+
+    @CommandHandler
+    constructor(command: CreateBankAccountCommand): this() {
+        apply(BankAccountCreatedEvent(command.bankAccountId, command.overdraftLimit))
+    }
+
+
+    @CommandHandler
+    fun deposit(command: DepositMoneyCommand) {
+        apply(MoneyDepositedEvent(id, command.amountOfMoney))
+    }
+
+    @CommandHandler
+    fun withdraw(command: WithdrawMoneyCommand) {
+        if (command.amountOfMoney <= balanceInCents + overdraftLimit) {
+            apply(MoneyWithdrawnEvent(id, command.amountOfMoney))
+        }
+    }
+
+    @CommandHandler
+    fun returnMoney(command: ReturnMoneyOfFailedBankTransferCommand) {
+        apply(MoneyOfFailedBankTransferReturnedEvent(id, command.amount))
+    }
+
+    fun debit(amount: Long, bankTransferId: String) {
+        if (amount <= balanceInCents + overdraftLimit) {
+            apply(SourceBankAccountDebitedEvent(id, amount, bankTransferId))
+        } else {
+            apply(SourceBankAccountDebitRejectedEvent(bankTransferId))
+        }
+    }
+
+    fun credit(amount: Long, bankTransferId: String) {
+        apply(DestinationBankAccountCreditedEvent(id, amount, bankTransferId))
+    }
+
+    @EventSourcingHandler
+    fun on(event: BankAccountCreatedEvent) {
+        id = event.id
+        overdraftLimit = event.overdraftLimit
+        balanceInCents = 0
+    }
+
+    @EventSourcingHandler
+    fun on(event: MoneyAddedEvent) {
+        balanceInCents += event.amount
+    }
+
+    @EventSourcingHandler
+    fun on(event: MoneySubtractedEvent) {
+        balanceInCents -= event.amount
+    }
+}

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/core/BankAccount.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/core/BankAccount.kt
@@ -35,18 +35,25 @@ class BankAccount() {
     private var overdraftLimit: Long = 0
     private var balanceInCents: Long = 0
 
-
+    /**
+     * Creates a new bank account.
+     */
     @CommandHandler
     constructor(command: CreateBankAccountCommand) : this() {
         apply(BankAccountCreatedEvent(command.bankAccountId, command.overdraftLimit))
     }
 
-
+    /**
+     * Deposits money to account.
+     */
     @CommandHandler
     fun deposit(command: DepositMoneyCommand) {
         apply(MoneyDepositedEvent(id, command.amountOfMoney))
     }
 
+    /**
+     * Withdraw money from account.
+     */
     @CommandHandler
     fun withdraw(command: WithdrawMoneyCommand) {
         if (command.amountOfMoney <= balanceInCents + overdraftLimit) {
@@ -54,23 +61,17 @@ class BankAccount() {
         }
     }
 
+    /**
+     * Return money from account.
+     */
     @CommandHandler
     fun returnMoney(command: ReturnMoneyOfFailedBankTransferCommand) {
         apply(MoneyOfFailedBankTransferReturnedEvent(id, command.amount))
     }
 
-    fun debit(amount: Long, bankTransferId: String) {
-        if (amount <= balanceInCents + overdraftLimit) {
-            apply(SourceBankAccountDebitedEvent(id, amount, bankTransferId))
-        } else {
-            apply(SourceBankAccountDebitRejectedEvent(bankTransferId))
-        }
-    }
-
-    fun credit(amount: Long, bankTransferId: String) {
-        apply(DestinationBankAccountCreditedEvent(id, amount, bankTransferId))
-    }
-
+    /**
+     * Handler to initialize bank accounts attributes.
+     */
     @EventSourcingHandler
     fun on(event: BankAccountCreatedEvent) {
         id = event.id
@@ -78,11 +79,17 @@ class BankAccount() {
         balanceInCents = 0
     }
 
+    /**
+     * Handler adjusting balance.
+     */
     @EventSourcingHandler
     fun on(event: MoneyAddedEvent) {
         balanceInCents += event.amount
     }
 
+    /**
+     * Handler adjusting balance.
+     */
     @EventSourcingHandler
     fun on(event: MoneySubtractedEvent) {
         balanceInCents -= event.amount

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/handler/BankEventHandler.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/handler/BankEventHandler.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extension.kafka.example.handler
+
+import mu.KLogging
+import org.axonframework.eventhandling.EventHandler
+import org.axonframework.eventhandling.EventMessage
+import org.springframework.stereotype.Component
+
+@Component
+class BankEventHandler {
+
+    companion object: KLogging()
+
+    @EventHandler
+    fun <T : EventMessage<Any>> on(event: T) {
+        logger.info { "received event ${event.payload}" }
+    }
+
+}

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/handler/BankEventHandler.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/handler/BankEventHandler.kt
@@ -29,6 +29,9 @@ class BankEventHandler {
 
     companion object: KLogging()
 
+    /**
+     * Receive all events and log them.
+     */
     @EventHandler
     fun <T : EventMessage<Any>> on(event: T) {
         logger.info { "received event ${event.payload}" }

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/handler/BankEventHandler.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/handler/BankEventHandler.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.axonframework.extension.kafka.example.handler
 
 import mu.KLogging
@@ -20,6 +21,9 @@ import org.axonframework.eventhandling.EventHandler
 import org.axonframework.eventhandling.EventMessage
 import org.springframework.stereotype.Component
 
+/**
+ * Collecting event handler for logging.
+ */
 @Component
 class BankEventHandler {
 

--- a/kafka-axon-example/src/main/resources/application-subscribing.yml
+++ b/kafka-axon-example/src/main/resources/application-subscribing.yml
@@ -1,0 +1,3 @@
+axon:
+  kafka:
+    event-processor-mode: subscribing

--- a/kafka-axon-example/src/main/resources/application-tracking.yml
+++ b/kafka-axon-example/src/main/resources/application-tracking.yml
@@ -1,0 +1,3 @@
+axon:
+  kafka:
+    event-processor-mode: tracking

--- a/kafka-axon-example/src/main/resources/application.yml
+++ b/kafka-axon-example/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: KafkaAxonExample
+
+axon:
+  kafka:
+    clientid: kafka-axon-example
+    defaulttopic: local.event
+    producer:
+      retries: 0
+      bootstrapservers: localhost:9092
+
+    properties:
+      security.protocol: PLAINTEXT

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -80,14 +80,20 @@ public class KafkaProperties {
      */
     private String clientId;
 
-
     /**
      * Default topic to which messages will be sent.
      */
     private String defaultTopic;
 
     /**
-     * Default handling mode is subscribing.
+     * Controls the mode of event processor responsible for sending messages to Kafka.
+     * <p>
+     * Depending on this, different error handling behaviours are taken in case of
+     * any errors during Kafka publishing.
+     * </p>
+     * <p>
+     * Possible values are "SUBSCRIBING" (default) and "TRACKING".
+     * </p>
      */
     private EventProcessorMode eventProcessorMode = EventProcessorMode.SUBSCRIBING;
 
@@ -499,7 +505,13 @@ public class KafkaProperties {
      * @author Simon Zambrovski
      */
     public enum EventProcessorMode {
+        /**
+         * Register publishing processor in subscribing mode.
+         */
         SUBSCRIBING,
+        /**
+         * Register publishing processor in tracking mode.
+         */
         TRACKING
     }
     /**

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -62,6 +62,7 @@ import java.util.Map;
  * @author Stephane Nicoll
  * @author Artem Bilan
  * @author Nakul Mishra
+ * @author Simon Zambrovski
  * @since 3.0
  */
 @ConfigurationProperties(prefix = "axon.kafka")
@@ -84,6 +85,11 @@ public class KafkaProperties {
      * Default topic to which messages will be sent.
      */
     private String defaultTopic;
+
+    /**
+     * Default handling mode is subscribing.
+     */
+    private EventProcessorMode eventProcessorMode = EventProcessorMode.SUBSCRIBING;
 
     /**
      * Additional properties, common to producers and consumers, used to configure the
@@ -146,6 +152,15 @@ public class KafkaProperties {
     public Ssl getSsl() {
         return this.ssl;
     }
+
+    public EventProcessorMode getEventProcessorMode() {
+        return eventProcessorMode;
+    }
+
+    public void setEventProcessorMode(EventProcessorMode eventProcessorMode) {
+        this.eventProcessorMode = eventProcessorMode;
+    }
+
 
     public void put(String key, String value) {
         this.properties.put(key, value);
@@ -474,6 +489,19 @@ public class KafkaProperties {
         }
     }
 
+    /**
+     * Modes for handler publishing messages from Axon to Kafka.
+     * <ul>
+     * <li>SUBSCRIBING: use kafka transactions while sending messages.</li>
+     * <li>TRACKING : use a individual tracking processor to publish messages.</li>
+     * </ul>
+     *
+     * @author Simon Zambrovski
+     */
+    public enum EventProcessorMode {
+        SUBSCRIBING,
+        TRACKING
+    }
     /**
      * Fetches messages from Kafka
      */

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -32,6 +32,7 @@
 
 package org.axonframework.extensions.kafka.autoconfig;
 
+import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.extensions.kafka.KafkaProperties;
 import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
 import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
@@ -44,10 +45,12 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.SortedKafkaMess
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode;
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaPublisher;
+import org.axonframework.extensions.kafka.eventhandling.producer.KafkaSendingEventHandler;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.springboot.autoconfig.AxonAutoConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -62,6 +65,7 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Map;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.axonframework.extensions.kafka.KafkaProperties.*;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Apache Kafka.
@@ -72,7 +76,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @Configuration
 @ConditionalOnClass(KafkaPublisher.class)
 @EnableConfigurationProperties(KafkaProperties.class)
-@AutoConfigureAfter({AxonAutoConfiguration.class})
+@AutoConfigureAfter({ AxonAutoConfiguration.class })
 public class KafkaAutoConfiguration {
 
     private final KafkaProperties properties;
@@ -91,10 +95,10 @@ public class KafkaAutoConfiguration {
             throw new IllegalStateException("transactionalIdPrefix cannot be empty");
         }
         return DefaultProducerFactory.<String, byte[]>builder()
-                .configuration(producer)
-                .confirmationMode(ConfirmationMode.TRANSACTIONAL)
-                .transactionalIdPrefix(transactionIdPrefix)
-                .build();
+            .configuration(producer)
+            .confirmationMode(ConfirmationMode.TRANSACTIONAL)
+            .transactionalIdPrefix(transactionIdPrefix)
+            .build();
     }
 
     @ConditionalOnMissingBean
@@ -107,36 +111,38 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     @Bean
     public KafkaMessageConverter<String, byte[]> kafkaMessageConverter(
-            @Qualifier("eventSerializer") Serializer eventSerializer) {
+        @Qualifier("eventSerializer") Serializer eventSerializer) {
         return DefaultKafkaMessageConverter.builder().serializer(eventSerializer).build();
     }
 
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutDown")
-    @ConditionalOnBean({ProducerFactory.class, KafkaMessageConverter.class})
-    public KafkaPublisher<String, byte[]> kafkaPublisher(ProducerFactory<String, byte[]> kafkaProducerFactory,
-                                                         KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
-                                                         AxonConfiguration configuration) {
+    @ConditionalOnBean({ ProducerFactory.class, KafkaMessageConverter.class })
+    public KafkaPublisher<String, byte[]> kafkaPublisher(
+        ProducerFactory<String, byte[]> kafkaProducerFactory,
+        KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
+        AxonConfiguration configuration) {
         return KafkaPublisher.<String, byte[]>builder()
-                .producerFactory(kafkaProducerFactory)
-                .messageConverter(kafkaMessageConverter)
-                .messageMonitor(configuration.messageMonitor(KafkaPublisher.class, "kafkaPublisher"))
-                .topic(properties.getDefaultTopic())
-                .build();
+            .producerFactory(kafkaProducerFactory)
+            .messageConverter(kafkaMessageConverter)
+            .messageMonitor(configuration.messageMonitor(KafkaPublisher.class, "kafkaPublisher"))
+            .topic(properties.getDefaultTopic())
+            .build();
     }
 
     @ConditionalOnMissingBean
-    @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class})
+    @ConditionalOnBean({ ConsumerFactory.class, KafkaMessageConverter.class })
     @Bean(destroyMethod = "shutdown")
-    public Fetcher kafkaFetcher(ConsumerFactory<String, byte[]> kafkaConsumerFactory,
-                                KafkaMessageConverter<String, byte[]> kafkaMessageConverter) {
+    public Fetcher kafkaFetcher(
+        ConsumerFactory<String, byte[]> kafkaConsumerFactory,
+        KafkaMessageConverter<String, byte[]> kafkaMessageConverter) {
         return AsyncFetcher.<String, byte[]>builder()
-                .consumerFactory(kafkaConsumerFactory)
-                .bufferFactory(() -> new SortedKafkaMessageBuffer<>(properties.getFetcher().getBufferSize()))
-                .messageConverter(kafkaMessageConverter)
-                .topic(properties.getDefaultTopic())
-                .pollTimeout(properties.getFetcher().getPollTimeout(), MILLISECONDS)
-                .build();
+            .consumerFactory(kafkaConsumerFactory)
+            .bufferFactory(() -> new SortedKafkaMessageBuffer<>(properties.getFetcher().getBufferSize()))
+            .messageConverter(kafkaMessageConverter)
+            .topic(properties.getDefaultTopic())
+            .pollTimeout(properties.getFetcher().getPollTimeout(), MILLISECONDS)
+            .build();
     }
 
     @ConditionalOnMissingBean
@@ -145,4 +151,29 @@ public class KafkaAutoConfiguration {
     public KafkaMessageSource kafkaMessageSource(Fetcher kafkaFetcher) {
         return new KafkaMessageSource(kafkaFetcher);
     }
+
+    @ConditionalOnBean({ EventProcessingConfigurer.class })
+    @Autowired
+    public void configureKafkaEventProcessor(
+        EventProcessingConfigurer eventProcessingConfigurer,
+        KafkaProperties kafkaProperties) {
+
+        final EventProcessorMode mode = kafkaProperties.getEventProcessorMode();
+        switch (mode) {
+            case SUBSCRIBING:
+                eventProcessingConfigurer.registerSubscribingEventProcessor(KafkaSendingEventHandler.GROUP);
+                return;
+            case TRACKING:
+                eventProcessingConfigurer.registerTrackingEventProcessor(KafkaSendingEventHandler.GROUP);
+                return;
+        }
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    @ConditionalOnBean({ KafkaPublisher.class })
+    public KafkaSendingEventHandler kafkaEventHandler(KafkaPublisher<String, byte[]> kafkaPublisher) {
+        return new KafkaSendingEventHandler(kafkaPublisher);
+    }
+
 }

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -153,7 +153,6 @@ public class KafkaAutoConfiguration {
         return new KafkaMessageSource(kafkaFetcher);
     }
 
-    @ConditionalOnBean({ EventProcessingConfigurer.class })
     @Autowired
     public void configureKafkaEventProcessor(
         final EventProcessingConfigurer eventProcessingConfigurer,

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -32,7 +32,6 @@
 
 package org.axonframework.extensions.kafka.autoconfig;
 
-import org.axonframework.eventhandling.EventBus;
 import org.axonframework.extensions.kafka.KafkaProperties;
 import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
 import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
@@ -113,14 +112,12 @@ public class KafkaAutoConfiguration {
     }
 
     @ConditionalOnMissingBean
-    @Bean(initMethod = "start", destroyMethod = "shutDown")
+    @Bean(destroyMethod = "shutDown")
     @ConditionalOnBean({ProducerFactory.class, KafkaMessageConverter.class})
     public KafkaPublisher<String, byte[]> kafkaPublisher(ProducerFactory<String, byte[]> kafkaProducerFactory,
-                                                         EventBus eventBus,
                                                          KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
                                                          AxonConfiguration configuration) {
         return KafkaPublisher.<String, byte[]>builder()
-                .messageSource(eventBus)
                 .producerFactory(kafkaProducerFactory)
                 .messageConverter(kafkaMessageConverter)
                 .messageMonitor(configuration.messageMonitor(KafkaPublisher.class, "kafkaPublisher"))

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -33,6 +33,7 @@
 package org.axonframework.extensions.kafka.autoconfig;
 
 import org.axonframework.config.EventProcessingConfigurer;
+import org.axonframework.eventhandling.PropagatingErrorHandler;
 import org.axonframework.extensions.kafka.KafkaProperties;
 import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
 import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
@@ -177,10 +178,7 @@ public class KafkaAutoConfiguration {
          */
         eventProcessingConfigurer.registerListenerInvocationErrorHandler(
             KafkaSendingEventHandler.GROUP,
-            configuration ->
-                (exception, event, eventHandler) -> {
-                    throw exception;
-                }
+            configuration -> PropagatingErrorHandler.instance()
         );
     }
 

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTests.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTests.java
@@ -345,6 +345,7 @@ public class KafkaAutoConfigurationTests {
             return mock(EventBus.class);
         }
 
+        @SuppressWarnings("unchecked")
         @Bean
         public AxonConfiguration axonConfiguration() {
             AxonConfiguration mock = mock(AxonConfiguration.class);

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTests.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTests.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.axonframework.config.EventProcessingConfigurer;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.extensions.kafka.KafkaProperties;
 import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
@@ -60,7 +61,7 @@ import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.config.AxonConfiguration;
-import org.junit.*;
+import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -72,7 +73,8 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link KafkaAutoConfiguration}.
@@ -81,25 +83,29 @@ import static org.mockito.Mockito.*;
  */
 public class KafkaAutoConfigurationTests {
 
+
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration.class));
 
     @Test
     public void minimalRequiredProperties() {
         this.contextRunner.withUserConfiguration(TestConfiguration.class)
-                          .withPropertyValues("axon.kafka.default-topic=testTopic",
-                                              "axon.kafka.producer.transaction-id-prefix=foo",
-                                              "axon.kafka.consumer.group-id=bar")
+                          .withPropertyValues(
+                              "axon.kafka.default-topic=testTopic",
+                              "axon.kafka.producer.transaction-id-prefix=foo",
+                              "axon.kafka.consumer.group-id=bar")
                           .run((context) -> {
                               DefaultProducerFactory producerFactory = ((DefaultProducerFactory<?, ?>) context
-                                      .getBean(DefaultProducerFactory.class));
+                                  .getBean(DefaultProducerFactory.class));
 
                               Map<String, Object> producerConfigs = ((DefaultProducerFactory<?, ?>) context
-                                      .getBean(DefaultProducerFactory.class)).configurationProperties();
+                                  .getBean(DefaultProducerFactory.class)).configurationProperties();
 
                               Map<String, Object> consumerConfigs = ((DefaultConsumerFactory<?, ?>) context
-                                      .getBean(DefaultConsumerFactory.class))
-                                      .configurationProperties();
+                                  .getBean(DefaultConsumerFactory.class))
+                                  .configurationProperties();
+
+                              KafkaProperties kafkaProperties = context.getBean(KafkaProperties.class);
 
                               // required beans
                               assertThat(context.getBeanNamesForType(ProducerFactory.class)).hasSize(1);
@@ -110,15 +116,15 @@ public class KafkaAutoConfigurationTests {
                               assertThat(context.getBeanNamesForType(KafkaMessageConverter.class)).hasSize(1);
 
                               assertThat(consumerConfigs.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))
-                                      .isEqualTo(Collections.singletonList("localhost:9092"));
+                                  .isEqualTo(Collections.singletonList("localhost:9092"));
 
                               //producer
                               assertThat(producerFactory.confirmationMode()).isEqualTo(ConfirmationMode.TRANSACTIONAL);
                               assertThat(producerFactory.transactionIdPrefix()).isEqualTo("foo");
                               assertThat(producerConfigs.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)).isEqualTo(
-                                      StringSerializer.class);
+                                  StringSerializer.class);
                               assertThat(producerConfigs.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG)).isEqualTo(
-                                      ByteArraySerializer.class);
+                                  ByteArraySerializer.class);
 
                               // consumer
                               assertThat(consumerConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG)).isNull();
@@ -129,49 +135,54 @@ public class KafkaAutoConfigurationTests {
                               assertThat(consumerConfigs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG)).isNull();
                               assertThat(consumerConfigs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isNull();
                               assertThat(consumerConfigs.get(ConsumerConfig.GROUP_ID_CONFIG))
-                                      .isEqualTo("bar");
+                                  .isEqualTo("bar");
                               assertThat(consumerConfigs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)).isNull();
                               assertThat(consumerConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
-                                      .isEqualTo(StringDeserializer.class);
+                                  .isEqualTo(StringDeserializer.class);
                               assertThat(
-                                      consumerConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
-                                      .isEqualTo(ByteArrayDeserializer.class);
+                                  consumerConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+                                  .isEqualTo(ByteArrayDeserializer.class);
+
+                              // default handler mode
+                              assertThat(kafkaProperties.getEventProcessorMode()).isEqualTo(KafkaProperties.EventProcessorMode.SUBSCRIBING);
+
                           });
     }
 
     @Test
     public void consumerProperties() {
         this.contextRunner.withUserConfiguration(TestConfiguration.class)
-                          .withPropertyValues("axon.kafka.default-topic=testTopic",
-                                              "axon.kafka.consumer.group-id=bar",
-                                              //override
-                                              "axon.kafka.bootstrap-servers=foo:1234",
-                                              "axon.kafka.properties.foo=bar",
-                                              "axon.kafka.default-topic=testTopic",
-                                              "axon.kafka.properties.baz=qux",
-                                              "axon.kafka.properties.foo.bar.baz=qux.fiz.buz",
-                                              "axon.kafka.ssl.key-password=p1",
-                                              "axon.kafka.ssl.keystore-location=classpath:ksLoc",
-                                              "axon.kafka.ssl.keystore-password=p2",
-                                              "axon.kafka.ssl.truststore-location=classpath:tsLoc",
-                                              "axon.kafka.ssl.truststore-password=p3",
-                                              "axon.kafka.consumer.auto-commit-interval=123",
-                                              "axon.kafka.consumer.max-poll-records=42",
-                                              "axon.kafka.consumer.auto-offset-reset=earliest",
-                                              "axon.kafka.consumer.client-id=ccid",
-                                              "axon.kafka.consumer.enable-auto-commit=false",
-                                              "axon.kafka.consumer.fetch-max-wait=456",
-                                              "axon.kafka.consumer.properties.fiz.buz=fix.fox",
-                                              "axon.kafka.consumer.fetch-min-size=789",
-                                              "axon.kafka.consumer.group-id=bar",
-                                              "axon.kafka.consumer.heartbeat-interval=234",
-                                              "axon.kafka.consumer.key-deserializer = org.apache.kafka.common.serialization.LongDeserializer",
-                                              "axon.kafka.consumer.value-deserializer = org.apache.kafka.common.serialization.IntegerDeserializer")
+                          .withPropertyValues(
+                              "axon.kafka.default-topic=testTopic",
+                              "axon.kafka.consumer.group-id=bar",
+                              //override
+                              "axon.kafka.bootstrap-servers=foo:1234",
+                              "axon.kafka.properties.foo=bar",
+                              "axon.kafka.default-topic=testTopic",
+                              "axon.kafka.properties.baz=qux",
+                              "axon.kafka.properties.foo.bar.baz=qux.fiz.buz",
+                              "axon.kafka.ssl.key-password=p1",
+                              "axon.kafka.ssl.keystore-location=classpath:ksLoc",
+                              "axon.kafka.ssl.keystore-password=p2",
+                              "axon.kafka.ssl.truststore-location=classpath:tsLoc",
+                              "axon.kafka.ssl.truststore-password=p3",
+                              "axon.kafka.consumer.auto-commit-interval=123",
+                              "axon.kafka.consumer.max-poll-records=42",
+                              "axon.kafka.consumer.auto-offset-reset=earliest",
+                              "axon.kafka.consumer.client-id=ccid",
+                              "axon.kafka.consumer.enable-auto-commit=false",
+                              "axon.kafka.consumer.fetch-max-wait=456",
+                              "axon.kafka.consumer.properties.fiz.buz=fix.fox",
+                              "axon.kafka.consumer.fetch-min-size=789",
+                              "axon.kafka.consumer.group-id=bar",
+                              "axon.kafka.consumer.heartbeat-interval=234",
+                              "axon.kafka.consumer.key-deserializer = org.apache.kafka.common.serialization.LongDeserializer",
+                              "axon.kafka.consumer.value-deserializer = org.apache.kafka.common.serialization.IntegerDeserializer")
                           .run((context) -> {
                               DefaultConsumerFactory<?, ?> consumerFactory = context
-                                      .getBean(DefaultConsumerFactory.class);
+                                  .getBean(DefaultConsumerFactory.class);
                               Map<String, Object> configs = consumerFactory
-                                      .configurationProperties();
+                                  .configurationProperties();
 
                               //required beans
                               assertThat(context.getBeanNamesForType(ConsumerFactory.class)).hasSize(1);
@@ -180,43 +191,43 @@ public class KafkaAutoConfigurationTests {
                               assertThat(context.getBeanNamesForType(KafkaMessageConverter.class)).hasSize(1);
 
                               assertThat(configs.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG))
-                                      .isEqualTo(Collections.singletonList("foo:1234"));
+                                  .isEqualTo(Collections.singletonList("foo:1234"));
                               assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG))
-                                      .isEqualTo("p1");
+                                  .isEqualTo("p1");
                               assertThat(
-                                      (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
-                                      .endsWith(File.separator + "ksLoc");
+                                  (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
+                                  .endsWith(File.separator + "ksLoc");
                               assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG))
-                                      .isEqualTo("p2");
+                                  .isEqualTo("p2");
                               assertThat((String) configs
-                                      .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
-                                      .endsWith(File.separator + "tsLoc");
+                                  .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
+                                  .endsWith(File.separator + "tsLoc");
                               assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG))
-                                      .isEqualTo("p3");
+                                  .isEqualTo("p3");
                               // consumer
                               assertThat(configs.get(ConsumerConfig.CLIENT_ID_CONFIG))
-                                      .isEqualTo("ccid");
+                                  .isEqualTo("ccid");
                               assertThat(configs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
-                                      .isEqualTo(Boolean.FALSE);
+                                  .isEqualTo(Boolean.FALSE);
                               assertThat(configs.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG))
-                                      .isEqualTo(123);
+                                  .isEqualTo(123);
                               assertThat(configs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
-                                      .isEqualTo("earliest");
+                                  .isEqualTo("earliest");
                               assertThat(configs.get(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG))
-                                      .isEqualTo(456);
+                                  .isEqualTo(456);
                               assertThat(configs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG))
-                                      .isEqualTo(789);
+                                  .isEqualTo(789);
                               assertThat(configs.get(ConsumerConfig.GROUP_ID_CONFIG))
-                                      .isEqualTo("bar");
+                                  .isEqualTo("bar");
                               assertThat(configs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG))
-                                      .isEqualTo(234);
+                                  .isEqualTo(234);
                               assertThat(configs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
-                                      .isEqualTo(LongDeserializer.class);
+                                  .isEqualTo(LongDeserializer.class);
                               assertThat(
-                                      configs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
-                                      .isEqualTo(IntegerDeserializer.class);
+                                  configs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+                                  .isEqualTo(IntegerDeserializer.class);
                               assertThat(configs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))
-                                      .isEqualTo(42);
+                                  .isEqualTo(42);
                               assertThat(configs.get("foo")).isEqualTo("bar");
                               assertThat(configs.get("baz")).isEqualTo("qux");
                               assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
@@ -228,64 +239,97 @@ public class KafkaAutoConfigurationTests {
     @Test
     public void producerProperties() {
         this.contextRunner.withUserConfiguration(TestConfiguration.class)
-                          .withPropertyValues("axon.kafka.clientId=cid",
-                                              "axon.kafka.default-topic=testTopic",
-                                              "axon.kafka.producer.transaction-id-prefix=foo",
-                                              "axon.kafka.properties.foo.bar.baz=qux.fiz.buz",
-                                              "axon.kafka.producer.acks=all",
-                                              "axon.kafka.producer.batch-size=20",
-                                              "axon.kafka.producer.bootstrap-servers=bar:1234",
-                                              // test
-                                              // override
-                                              "axon.kafka.producer.buffer-memory=12345",
-                                              "axon.kafka.producer.compression-type=gzip",
-                                              "axon.kafka.producer.key-serializer=org.apache.kafka.common.serialization.LongSerializer",
-                                              "axon.kafka.producer.retries=2",
-                                              "axon.kafka.producer.properties.fiz.buz=fix.fox",
-                                              "axon.kafka.producer.ssl.key-password=p4",
-                                              "axon.kafka.producer.ssl.keystore-location=classpath:ksLocP",
-                                              "axon.kafka.producer.ssl.keystore-password=p5",
-                                              "axon.kafka.producer.ssl.truststore-location=classpath:tsLocP",
-                                              "axon.kafka.producer.ssl.truststore-password=p6",
-                                              "axon.kafka.producer.value-serializer=org.apache.kafka.common.serialization.IntegerSerializer")
+                          .withPropertyValues(
+                              "axon.kafka.clientId=cid",
+                              "axon.kafka.default-topic=testTopic",
+                              "axon.kafka.producer.transaction-id-prefix=foo",
+                              "axon.kafka.properties.foo.bar.baz=qux.fiz.buz",
+                              "axon.kafka.producer.acks=all",
+                              "axon.kafka.producer.batch-size=20",
+                              "axon.kafka.producer.bootstrap-servers=bar:1234",
+                              // test
+                              // override
+                              "axon.kafka.producer.buffer-memory=12345",
+                              "axon.kafka.producer.compression-type=gzip",
+                              "axon.kafka.producer.key-serializer=org.apache.kafka.common.serialization.LongSerializer",
+                              "axon.kafka.producer.retries=2",
+                              "axon.kafka.producer.properties.fiz.buz=fix.fox",
+                              "axon.kafka.producer.ssl.key-password=p4",
+                              "axon.kafka.producer.ssl.keystore-location=classpath:ksLocP",
+                              "axon.kafka.producer.ssl.keystore-password=p5",
+                              "axon.kafka.producer.ssl.truststore-location=classpath:tsLocP",
+                              "axon.kafka.producer.ssl.truststore-password=p6",
+                              "axon.kafka.producer.value-serializer=org.apache.kafka.common.serialization.IntegerSerializer")
                           .run((context) -> {
                               DefaultProducerFactory<?, ?> producerFactory = context
-                                      .getBean(DefaultProducerFactory.class);
+                                  .getBean(DefaultProducerFactory.class);
                               Map<String, Object> configs = producerFactory
-                                      .configurationProperties();
+                                  .configurationProperties();
                               // common
                               assertThat(configs.get(ProducerConfig.CLIENT_ID_CONFIG))
-                                      .isEqualTo("cid");
+                                  .isEqualTo("cid");
                               // producer
                               assertThat(configs.get(ProducerConfig.ACKS_CONFIG)).isEqualTo("all");
                               assertThat(configs.get(ProducerConfig.BATCH_SIZE_CONFIG))
-                                      .isEqualTo(20);
+                                  .isEqualTo(20);
                               assertThat(configs.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
-                                      .isEqualTo(Collections.singletonList("bar:1234")); // override
+                                  .isEqualTo(Collections.singletonList("bar:1234")); // override
                               assertThat(configs.get(ProducerConfig.BUFFER_MEMORY_CONFIG))
-                                      .isEqualTo(12345L);
+                                  .isEqualTo(12345L);
                               assertThat(configs.get(ProducerConfig.COMPRESSION_TYPE_CONFIG))
-                                      .isEqualTo("gzip");
+                                  .isEqualTo("gzip");
                               assertThat(configs.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
-                                      .isEqualTo(LongSerializer.class);
+                                  .isEqualTo(LongSerializer.class);
                               assertThat(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG))
-                                      .isEqualTo("p4");
+                                  .isEqualTo("p4");
                               assertThat(
-                                      (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
-                                      .endsWith(File.separator + "ksLocP");
+                                  (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
+                                  .endsWith(File.separator + "ksLocP");
                               assertThat(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG))
-                                      .isEqualTo("p5");
+                                  .isEqualTo("p5");
                               assertThat((String) configs
-                                      .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
-                                      .endsWith(File.separator + "tsLocP");
+                                  .get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
+                                  .endsWith(File.separator + "tsLocP");
                               assertThat(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG))
-                                      .isEqualTo("p6");
+                                  .isEqualTo("p6");
                               assertThat(configs.get(ProducerConfig.RETRIES_CONFIG)).isEqualTo(2);
                               assertThat(configs.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))
-                                      .isEqualTo(IntegerSerializer.class);
+                                  .isEqualTo(IntegerSerializer.class);
                               assertThat(configs.get("foo.bar.baz")).isEqualTo("qux.fiz.buz");
                               assertThat(configs.get("fiz.buz")).isEqualTo("fix.fox");
                           });
+    }
+
+    @Test
+    public void kafkaPropertiesTrackingMode() {
+        this.contextRunner.withUserConfiguration(TestConfiguration.class)
+                          .withPropertyValues(
+                              // minimal
+                              "axon.kafka.default-topic=testTopic",
+                              "axon.kafka.producer.transaction-id-prefix=foo",
+                              "axon.kafka.consumer.group-id=bar",
+                              // mode
+                              "axon.kafka.event-processor-mode=TRACKING"
+                          ).run((context) -> {
+            KafkaProperties kafkaProperties = context.getBean(KafkaProperties.class);
+            assertThat(kafkaProperties.getEventProcessorMode()).isEqualTo(KafkaProperties.EventProcessorMode.TRACKING);
+        });
+    }
+
+    @Test
+    public void kafkaPropertiesSubscribingMode() {
+        this.contextRunner.withUserConfiguration(TestConfiguration.class)
+                          .withPropertyValues(
+                              // minimal
+                              "axon.kafka.default-topic=testTopic",
+                              "axon.kafka.producer.transaction-id-prefix=foo",
+                              "axon.kafka.consumer.group-id=bar",
+                              // handling mode
+                              "axon.kafka.event-processor-mode=SUBSCRIBING"
+                          ).run((context) -> {
+            KafkaProperties kafkaProperties = context.getBean(KafkaProperties.class);
+            assertThat(kafkaProperties.getEventProcessorMode()).isEqualTo(KafkaProperties.EventProcessorMode.SUBSCRIBING);
+        });
     }
 
     @Configuration
@@ -306,6 +350,11 @@ public class KafkaAutoConfigurationTests {
             AxonConfiguration mock = mock(AxonConfiguration.class);
             when(mock.messageMonitor(any(), any())).thenReturn((MessageMonitor) NoOpMessageMonitor.instance());
             return mock;
+        }
+
+        @Bean
+        public EventProcessingConfigurer configurer() {
+            return mock(EventProcessingConfigurer.class);
         }
     }
 }

--- a/kafka-spring-boot-starter/pom.xml
+++ b/kafka-spring-boot-starter/pom.xml
@@ -17,14 +17,13 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starters</artifactId>
-        <version>2.0.3.RELEASE</version>
-        <relativePath />
+        <groupId>org.axonframework.extensions.kafka</groupId>
+        <artifactId>axon-kafka-parent</artifactId>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.axonframework.extensions.kafka</groupId>
     <artifactId>axon-kafka-spring-boot-starter</artifactId>
     <version>4.0-SNAPSHOT</version>
 
@@ -35,17 +34,6 @@
         <name>AxonIQ B.V.</name>
         <url>https://axoniq.io</url>
     </organization>
-
-    <licenses>
-        <license>
-            <name>Apache 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/AxonFramework/extension-kafka/issues</url>
-    </issueManagement>
 
     <dependencies>
         <dependency>
@@ -138,24 +126,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <uniqueVersion>true</uniqueVersion>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-            <uniqueVersion>false</uniqueVersion>
-        </repository>
-    </distributionManagement>
-    <scm>
-        <connection>scm:git:git://github.com/AxonFramework/extension-kafka.git</connection>
-        <developerConnection>scm:git:git@github.com:AxonFramework/extension-kafka.git</developerConnection>
-        <url>https://github.com/AxonFramework/extension-kafka</url>
-        <tag>HEAD</tag>
-    </scm>
 
 </project>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -44,6 +44,17 @@
             <artifactId>axon-messaging</artifactId>
             <version>${axon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-configuration</artifactId>
+            <version>${axon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -111,8 +122,9 @@
                                         <exclude>org.springframework</exclude>
                                     </excludes>
                                     <includes>
-                                        <!-- allow any spring dependency with test scope -->
+                                        <!-- allow any spring dependency with test or provided scopes -->
                                         <include>org.springframework:*:*:*:test</include>
+                                        <include>org.springframework:*:*:*:provided</include>
                                     </includes>
                                 </bannedDependencies>
                             </rules>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -50,13 +50,6 @@
             <version>${axon.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
             <version>${kafka.version}</version>
@@ -124,7 +117,6 @@
                                     <includes>
                                         <!-- allow any spring dependency with test or provided scopes -->
                                         <include>org.springframework:*:*:*:test</include>
-                                        <include>org.springframework:*:*:*:provided</include>
                                     </includes>
                                 </bannedDependencies>
                             </rules>

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/HeaderUtils.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/HeaderUtils.java
@@ -47,7 +47,22 @@ public class HeaderUtils {
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private HeaderUtils() {
-        // private ctor
+  /*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+      // private ctor
     }
 
     /**

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactory.java
@@ -32,6 +32,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactory.java
@@ -32,7 +32,6 @@ import org.axonframework.common.AxonConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -103,6 +102,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
      *
      * @param <K> a generic type for the key of the {@link Producer} this {@link ProducerFactory} will create
      * @param <V> a generic type for the value of the {@link Producer} this {@link ProducerFactory} will create
+     *
      * @return a Builder to be able to create a {@link DefaultProducerFactory}
      */
     public static <K, V> Builder<K, V> builder() {
@@ -122,10 +122,11 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
         if (this.producer == null) {
             synchronized (this) {
                 if (this.producer == null) {
-                    this.producer = new CloseLazyProducer<>(createKafkaProducer(configuration),
-                                                            cache,
-                                                            closeTimeout,
-                                                            timeUnit);
+                    this.producer = new CloseLazyProducer<>(
+                        createKafkaProducer(configuration),
+                        cache,
+                        closeTimeout,
+                        timeUnit);
                 }
             }
         }
@@ -188,8 +189,9 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
             return producer;
         }
         Map<String, Object> configs = new HashMap<>(this.configuration);
-        configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG,
-                    this.transactionIdPrefix + this.transactionIdSuffix.getAndIncrement());
+        configs.put(
+            ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+            this.transactionIdPrefix + this.transactionIdSuffix.getAndIncrement());
         producer = new CloseLazyProducer<>(createKafkaProducer(configs), cache, closeTimeout, timeUnit);
         producer.initTransactions();
         return producer;
@@ -206,8 +208,9 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
         private final int closeTimeout;
         private final TimeUnit unit;
 
-        CloseLazyProducer(Producer<K, V> delegate, BlockingQueue<CloseLazyProducer<K, V>> cache, int closeTimeout,
-                          TimeUnit unit) {
+        CloseLazyProducer(
+            Producer<K, V> delegate, BlockingQueue<CloseLazyProducer<K, V>> cache, int closeTimeout,
+            TimeUnit unit) {
             this.delegate = delegate;
             this.cache = cache;
             this.closeTimeout = closeTimeout;
@@ -251,7 +254,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
 
         @Override
         public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId)
-                throws ProducerFencedException {
+            throws ProducerFencedException {
             this.delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
         }
 
@@ -311,6 +314,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
          * @param timeout  the time to wait before invoking {@link Producer#close(long, TimeUnit)} in units of
          *                 {@code timeUnit}.
          * @param timeUnit a {@code TimeUnit} determining how to interpret the {@code timeout} parameter
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> closeTimeout(int timeout, TimeUnit timeUnit) {
@@ -327,6 +331,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
          * Will instantiate an {@link ArrayBlockingQueue} based on this number.
          *
          * @param producerCacheSize an {@code int} specifying the number of {@link Producer} instances to cache
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> producerCacheSize(int producerCacheSize) {
@@ -340,6 +345,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
          *
          * @param configuration a {@link Map} of {@link String} to {@link Object} containing Kafka properties for
          *                      creating {@link Producer} instances
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> configuration(Map<String, Object> configuration) {
@@ -353,6 +359,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
          * {@link ConfirmationMode#NONE}.
          *
          * @param confirmationMode the {@link ConfirmationMode} for producing {@link Producer} instances
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> confirmationMode(ConfirmationMode confirmationMode) {
@@ -366,6 +373,7 @@ public class DefaultProducerFactory<K, V> implements ProducerFactory<K, V> {
          *
          * @param transactionIdPrefix a {@link String} specifying the prefix used to generate the
          *                            {@code transactional.id} required for transactional {@link Producer}s
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> transactionalIdPrefix(String transactionIdPrefix) {

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -65,8 +65,6 @@ public class KafkaPublisher<K, V> {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaPublisher.class);
 
-    private static final String EXCEPTION_KEY = KafkaPublisher.class.getName() + ".EXCEPTION";
-
     private final ProducerFactory<K, V> producerFactory;
     private final KafkaMessageConverter<K, V> messageConverter;
     private final MessageMonitor<? super EventMessage<?>> messageMonitor;
@@ -81,7 +79,7 @@ public class KafkaPublisher<K, V> {
      *
      * @param builder the {@link Builder} used to instantiate a {@link KafkaPublisher} instance
      */
-    private KafkaPublisher(Builder<K, V> builder) {
+    protected KafkaPublisher(Builder<K, V> builder) {
         builder.validate();
         this.producerFactory = builder.producerFactory;
         this.messageConverter = builder.messageConverter;
@@ -310,6 +308,7 @@ public class KafkaPublisher<K, V> {
          *
          * @return the current Builder instance, for fluent interfacing
          */
+        @SuppressWarnings("WeakerAccess")
         public Builder<K, V> publisherAckTimeout(long publisherAckTimeout) {
             assertThat(
                 publisherAckTimeout,
@@ -334,6 +333,7 @@ public class KafkaPublisher<K, V> {
          * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
          *                                    specifications
          */
+        @SuppressWarnings("WeakerAccess")
         protected void validate() throws AxonConfigurationException {
             assertNonNull(producerFactory, "The ProducerFactory is a hard requirement and should be provided");
         }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -20,10 +20,9 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.axonframework.common.AxonConfigurationException;
-import org.axonframework.common.Registration;
 import org.axonframework.eventhandling.EventMessage;
-import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import org.axonframework.messaging.EventPublicationFailedException;
 import org.axonframework.messaging.SubscribableMessageSource;
 import org.axonframework.messaging.unitofwork.CurrentUnitOfWork;
@@ -58,6 +57,7 @@ import static org.axonframework.common.BuilderUtils.assertThat;
  *            {@link KafkaMessageConverter}
  * @param <V> a generic type for the value of the {@link ProducerFactory}, {@link Producer} and
  *            {@link KafkaMessageConverter}
+ *
  * @author Nakul Mishra
  * @since 3.0
  */
@@ -65,26 +65,22 @@ public class KafkaPublisher<K, V> {
 
     private static final Logger logger = LoggerFactory.getLogger(KafkaPublisher.class);
 
-    private final SubscribableMessageSource<EventMessage<?>> messageSource;
     private final ProducerFactory<K, V> producerFactory;
     private final KafkaMessageConverter<K, V> messageConverter;
     private final MessageMonitor<? super EventMessage<?>> messageMonitor;
     private final String topic;
     private final long publisherAckTimeout;
 
-    private Registration eventBusRegistration;
-
     /**
      * Instantiate a {@link KafkaPublisher} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link SubscribableMessageSource} and {@link ProducerFactory} are not {@code null}, and will
+     * Will assert that {@link ProducerFactory} are not {@code null}, and will
      * throw an {@link AxonConfigurationException} if any of them is {@code null}.
      *
      * @param builder the {@link Builder} used to instantiate a {@link KafkaPublisher} instance
      */
-    protected KafkaPublisher(Builder<K, V> builder) {
+    private KafkaPublisher(Builder<K, V> builder) {
         builder.validate();
-        this.messageSource = builder.messageSource;
         this.producerFactory = builder.producerFactory;
         this.messageConverter = builder.messageConverter;
         this.messageMonitor = builder.messageMonitor;
@@ -104,6 +100,7 @@ public class KafkaPublisher<K, V> {
      *            {@link KafkaMessageConverter}
      * @param <V> a generic type for the value of the {@link ProducerFactory}, {@link Producer} and
      *            {@link KafkaMessageConverter}
+     *
      * @return a Builder to be able to create a {@link KafkaPublisher}
      */
     public static <K, V> Builder<K, V> builder() {
@@ -111,20 +108,9 @@ public class KafkaPublisher<K, V> {
     }
 
     /**
-     * Subscribes this publisher to the messageSource provided during initialization.
-     */
-    public void start() {
-        eventBusRegistration = messageSource.subscribe(this::send);
-    }
-
-    /**
      * Shuts down this component and unsubscribes it from its messageSource.
      */
     public void shutDown() {
-        if (eventBusRegistration != null) {
-            eventBusRegistration.cancel();
-            eventBusRegistration = null;
-        }
         producerFactory.shutDown();
     }
 
@@ -142,9 +128,9 @@ public class KafkaPublisher<K, V> {
      *
      * @param events the events to publish on the Kafka broker.
      */
-    protected void send(List<? extends EventMessage<?>> events) {
+    public void send(List<? extends EventMessage<?>> events) {
         final Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks = messageMonitor
-                .onMessagesIngested(events);
+            .onMessagesIngested(events);
         Producer<K, V> producer = producerFactory.createProducer();
         ConfirmationMode cm = producerFactory.confirmationMode();
         try {
@@ -171,11 +157,13 @@ public class KafkaPublisher<K, V> {
      *
      * @param events   list of event messages to publish.
      * @param producer Kafka producer used for publishing.
+     *
      * @return Map containing futures for each event that was published to kafka. You can interact with a specific
      * {@link Future} to check whether a giSpringAxonAutoConfigurerTestven message was published successfully or not.
      */
-    private Map<Future<RecordMetadata>, ? super EventMessage<?>> publishToKafka(List<? extends EventMessage<?>> events,
-                                                                                Producer<K, V> producer) {
+    private Map<Future<RecordMetadata>, ? super EventMessage<?>> publishToKafka(
+        List<? extends EventMessage<?>> events,
+        Producer<K, V> producer) {
         Map<Future<RecordMetadata>, ? super EventMessage<?>> results = new HashMap<>();
         events.forEach(event -> results.put(producer.send(messageConverter.createKafkaMessage(event, topic)), event));
         return results;
@@ -184,18 +172,20 @@ public class KafkaPublisher<K, V> {
     /**
      * Commit/rollback Kafka work once a given unit of work is committed/rollback.
      */
-    private void handleActiveUnitOfWork(Producer<K, V> producer,
-                                        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
-                                        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks,
-                                        ConfirmationMode confirmationMode) {
+    private void handleActiveUnitOfWork(
+        Producer<K, V> producer,
+        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
+        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks,
+        ConfirmationMode confirmationMode) {
         UnitOfWork<?> uow = CurrentUnitOfWork.get();
         uow.afterCommit(u -> completeKafkaWork(monitorCallbacks, producer, confirmationMode, futures));
         uow.onRollback(u -> rollbackKafkaWork(producer, confirmationMode));
     }
 
-    private void completeKafkaWork(Map<? super EventMessage<?>, MonitorCallback> monitorCallbackMap,
-                                   Producer<K, V> producer, ConfirmationMode confirmationMode,
-                                   Map<Future<RecordMetadata>, ? super EventMessage<?>> futures) {
+    private void completeKafkaWork(
+        Map<? super EventMessage<?>, MonitorCallback> monitorCallbackMap,
+        Producer<K, V> producer, ConfirmationMode confirmationMode,
+        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures) {
         if (confirmationMode.isTransactional()) {
             tryCommit(producer, monitorCallbackMap);
         } else if (confirmationMode.isWaitForAck()) {
@@ -212,8 +202,9 @@ public class KafkaPublisher<K, V> {
     }
 
     @SuppressWarnings("SuspiciousMethodCalls")
-    private void waitForPublishAck(Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
-                                   Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
+    private void waitForPublishAck(
+        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
+        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
         long deadline = System.currentTimeMillis() + publisherAckTimeout;
         futures.forEach((k, v) -> {
             try {
@@ -234,13 +225,14 @@ public class KafkaPublisher<K, V> {
         } catch (ProducerFencedException e) {
             logger.warn("Unable to begin transaction", e);
             throw new EventPublicationFailedException(
-                    "Event publication failed: Exception occurred while starting kafka transaction",
-                    e);
+                "Event publication failed: Exception occurred while starting kafka transaction",
+                e);
         }
     }
 
-    private void tryCommit(Producer<?, ?> producer,
-                           Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
+    private void tryCommit(
+        Producer<?, ?> producer,
+        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
         try {
             producer.commitTransaction();
             monitorCallbacks.forEach((k, v) -> v.reportSuccess());
@@ -248,8 +240,8 @@ public class KafkaPublisher<K, V> {
             logger.warn("Unable to commit transaction", e);
             monitorCallbacks.forEach((k, v) -> v.reportFailure(e));
             throw new EventPublicationFailedException(
-                    "Event publication failed: Exception occurred while committing kafka transaction",
-                    e);
+                "Event publication failed: Exception occurred while committing kafka transaction",
+                e);
         }
     }
 
@@ -286,31 +278,16 @@ public class KafkaPublisher<K, V> {
      */
     public static class Builder<K, V> {
 
-        private SubscribableMessageSource<EventMessage<?>> messageSource;
         private ProducerFactory<K, V> producerFactory;
         @SuppressWarnings("unchecked")
         private KafkaMessageConverter<K, V> messageConverter =
-                (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
-                                                                          .serializer(XStreamSerializer.builder()
-                                                                                                       .build())
-                                                                          .build();
+            (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
+                                                                      .serializer(XStreamSerializer.builder()
+                                                                                                   .build())
+                                                                      .build();
         private MessageMonitor<? super EventMessage<?>> messageMonitor = NoOpMessageMonitor.instance();
         private String topic = "Axon.Events";
         private long publisherAckTimeout = 1_000;
-
-        /**
-         * Sets the {@link SubscribableMessageSource} of type {@link EventMessage} which will provide the EventMessages
-         * to be published on the Kafka topic.
-         *
-         * @param messageSource a {@link SubscribableMessageSource} of type {@link EventMessage} which will provide the
-         *                      EventMessages to be published on the Kafka topic
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder<K, V> messageSource(SubscribableMessageSource<EventMessage<?>> messageSource) {
-            assertNonNull(messageSource, "SubscribableMessageSource may not be null");
-            this.messageSource = messageSource;
-            return this;
-        }
 
         /**
          * Sets the {@link ProducerFactory} which will instantiate {@link Producer} instances to publish
@@ -318,6 +295,7 @@ public class KafkaPublisher<K, V> {
          *
          * @param producerFactory a {@link ProducerFactory} which will instantiate {@link Producer} instances to publish
          *                        {@link EventMessage}s on the Kafka topic
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> producerFactory(ProducerFactory<K, V> producerFactory) {
@@ -334,6 +312,7 @@ public class KafkaPublisher<K, V> {
          *
          * @param messageConverter a {@link KafkaMessageConverter} used to convert {@link EventMessage}s into Kafka
          *                         messages
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> messageConverter(KafkaMessageConverter<K, V> messageConverter) {
@@ -347,6 +326,7 @@ public class KafkaPublisher<K, V> {
          * publisher. Defaults to a {@link NoOpMessageMonitor}.
          *
          * @param messageMonitor a {@link MessageMonitor} used to monitor this Kafka publisher
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> messageMonitor(MessageMonitor<? super EventMessage<?>> messageMonitor) {
@@ -359,6 +339,7 @@ public class KafkaPublisher<K, V> {
          * Set the Kafka {@code topic} to publish {@link EventMessage}s on. Defaults to {@code Axon.Events}.
          *
          * @param topic the Kafka {@code topic} to publish {@link EventMessage}s on
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> topic(String topic) {
@@ -373,12 +354,14 @@ public class KafkaPublisher<K, V> {
          *
          * @param publisherAckTimeout a {@code long} specifying how long to wait for a publisher to acknowledge a
          *                            message has been sent
+         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> publisherAckTimeout(long publisherAckTimeout) {
-            assertThat(publisherAckTimeout,
-                       timeout -> timeout >= 0,
-                       "The publisherAckTimeout should be a positive number or zero");
+            assertThat(
+                publisherAckTimeout,
+                timeout -> timeout >= 0,
+                "The publisherAckTimeout should be a positive number or zero");
             this.publisherAckTimeout = publisherAckTimeout;
             return this;
         }
@@ -399,7 +382,6 @@ public class KafkaPublisher<K, V> {
          *                                    specifications
          */
         protected void validate() throws AxonConfigurationException {
-            assertNonNull(messageSource, "The SubscribableMessageSource is a hard requirement and should be provided");
             assertNonNull(producerFactory, "The ProducerFactory is a hard requirement and should be provided");
         }
     }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -157,13 +157,11 @@ public class KafkaPublisher<K, V> {
      *
      * @param events   list of event messages to publish.
      * @param producer Kafka producer used for publishing.
-     *
      * @return Map containing futures for each event that was published to kafka. You can interact with a specific
      * {@link Future} to check whether a giSpringAxonAutoConfigurerTestven message was published successfully or not.
      */
-    private Map<Future<RecordMetadata>, ? super EventMessage<?>> publishToKafka(
-        List<? extends EventMessage<?>> events,
-        Producer<K, V> producer) {
+    private Map<Future<RecordMetadata>, ? super EventMessage<?>> publishToKafka(List<? extends EventMessage<?>> events,
+                                                                                Producer<K, V> producer) {
         Map<Future<RecordMetadata>, ? super EventMessage<?>> results = new HashMap<>();
         events.forEach(event -> results.put(producer.send(messageConverter.createKafkaMessage(event, topic)), event));
         return results;
@@ -172,20 +170,18 @@ public class KafkaPublisher<K, V> {
     /**
      * Commit/rollback Kafka work once a given unit of work is committed/rollback.
      */
-    private void handleActiveUnitOfWork(
-        Producer<K, V> producer,
-        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
-        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks,
-        ConfirmationMode confirmationMode) {
+    private void handleActiveUnitOfWork(Producer<K, V> producer,
+                                        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
+                                        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks,
+                                        ConfirmationMode confirmationMode) {
         UnitOfWork<?> uow = CurrentUnitOfWork.get();
         uow.afterCommit(u -> completeKafkaWork(monitorCallbacks, producer, confirmationMode, futures));
         uow.onRollback(u -> rollbackKafkaWork(producer, confirmationMode));
     }
 
-    private void completeKafkaWork(
-        Map<? super EventMessage<?>, MonitorCallback> monitorCallbackMap,
-        Producer<K, V> producer, ConfirmationMode confirmationMode,
-        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures) {
+    private void completeKafkaWork(Map<? super EventMessage<?>, MonitorCallback> monitorCallbackMap,
+                                   Producer<K, V> producer, ConfirmationMode confirmationMode,
+                                   Map<Future<RecordMetadata>, ? super EventMessage<?>> futures) {
         if (confirmationMode.isTransactional()) {
             tryCommit(producer, monitorCallbackMap);
         } else if (confirmationMode.isWaitForAck()) {
@@ -202,9 +198,8 @@ public class KafkaPublisher<K, V> {
     }
 
     @SuppressWarnings("SuspiciousMethodCalls")
-    private void waitForPublishAck(
-        Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
-        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
+    private void waitForPublishAck(Map<Future<RecordMetadata>, ? super EventMessage<?>> futures,
+                                   Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
         long deadline = System.currentTimeMillis() + publisherAckTimeout;
         futures.forEach((k, v) -> {
             try {
@@ -225,14 +220,13 @@ public class KafkaPublisher<K, V> {
         } catch (ProducerFencedException e) {
             logger.warn("Unable to begin transaction", e);
             throw new EventPublicationFailedException(
-                "Event publication failed: Exception occurred while starting kafka transaction",
-                e);
+                    "Event publication failed: Exception occurred while starting kafka transaction",
+                    e);
         }
     }
 
-    private void tryCommit(
-        Producer<?, ?> producer,
-        Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
+    private void tryCommit(Producer<?, ?> producer,
+                           Map<? super EventMessage<?>, MonitorCallback> monitorCallbacks) {
         try {
             producer.commitTransaction();
             monitorCallbacks.forEach((k, v) -> v.reportSuccess());
@@ -240,8 +234,8 @@ public class KafkaPublisher<K, V> {
             logger.warn("Unable to commit transaction", e);
             monitorCallbacks.forEach((k, v) -> v.reportFailure(e));
             throw new EventPublicationFailedException(
-                "Event publication failed: Exception occurred while committing kafka transaction",
-                e);
+                    "Event publication failed: Exception occurred while committing kafka transaction",
+                    e);
         }
     }
 
@@ -281,10 +275,10 @@ public class KafkaPublisher<K, V> {
         private ProducerFactory<K, V> producerFactory;
         @SuppressWarnings("unchecked")
         private KafkaMessageConverter<K, V> messageConverter =
-            (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
-                                                                      .serializer(XStreamSerializer.builder()
-                                                                                                   .build())
-                                                                      .build();
+                (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
+                                                                          .serializer(XStreamSerializer.builder()
+                                                                                                       .build())
+                                                                          .build();
         private MessageMonitor<? super EventMessage<?>> messageMonitor = NoOpMessageMonitor.instance();
         private String topic = "Axon.Events";
         private long publisherAckTimeout = 1_000;
@@ -295,7 +289,6 @@ public class KafkaPublisher<K, V> {
          *
          * @param producerFactory a {@link ProducerFactory} which will instantiate {@link Producer} instances to publish
          *                        {@link EventMessage}s on the Kafka topic
-         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> producerFactory(ProducerFactory<K, V> producerFactory) {
@@ -312,7 +305,6 @@ public class KafkaPublisher<K, V> {
          *
          * @param messageConverter a {@link KafkaMessageConverter} used to convert {@link EventMessage}s into Kafka
          *                         messages
-         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> messageConverter(KafkaMessageConverter<K, V> messageConverter) {
@@ -326,7 +318,6 @@ public class KafkaPublisher<K, V> {
          * publisher. Defaults to a {@link NoOpMessageMonitor}.
          *
          * @param messageMonitor a {@link MessageMonitor} used to monitor this Kafka publisher
-         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> messageMonitor(MessageMonitor<? super EventMessage<?>> messageMonitor) {
@@ -339,7 +330,6 @@ public class KafkaPublisher<K, V> {
          * Set the Kafka {@code topic} to publish {@link EventMessage}s on. Defaults to {@code Axon.Events}.
          *
          * @param topic the Kafka {@code topic} to publish {@link EventMessage}s on
-         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> topic(String topic) {
@@ -354,14 +344,12 @@ public class KafkaPublisher<K, V> {
          *
          * @param publisherAckTimeout a {@code long} specifying how long to wait for a publisher to acknowledge a
          *                            message has been sent
-         *
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> publisherAckTimeout(long publisherAckTimeout) {
-            assertThat(
-                publisherAckTimeout,
-                timeout -> timeout >= 0,
-                "The publisherAckTimeout should be a positive number or zero");
+            assertThat(publisherAckTimeout,
+                       timeout -> timeout >= 0,
+                       "The publisherAckTimeout should be a positive number or zero");
             this.publisherAckTimeout = publisherAckTimeout;
             return this;
         }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
@@ -20,18 +20,38 @@ import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
 
+/**
+ * Event handler responsible for sending messages to Kafka using provided {@link KafkaPublisher}.
+ * <p>
+ * This class is intentionally not a Spring Component, but is initialized during auto-configuration
+ * taking the EventProcessor Mode into account.
+ * </p>
+ * This class is not intended to be neither sub-classed nor instantiated by the end user of the extension.
+ */
 @SuppressWarnings("UNUSED")
 @ProcessingGroup(KafkaSendingEventHandler.GROUP)
 public class KafkaSendingEventHandler {
 
+    /**
+     * Kafka Event Handler processing group.
+     */
     public static final String GROUP = "axon.kafka.event";
 
     private final KafkaPublisher kafkaPublisher;
 
+    /**
+     * Constructs the event handler.
+     * @param kafkaPublisher publisher to be used to send message to Kafka and acknowledge them.
+     */
     public KafkaSendingEventHandler(KafkaPublisher kafkaPublisher) {
         this.kafkaPublisher = kafkaPublisher;
     }
 
+    /**
+     * Main event handling method matching all events and delegating them to Kafka.
+     * @param message event received.
+     * @param <T> event type.
+     */
     @EventHandler
     public <T> void handle(EventMessage<T> message) {
         kafkaPublisher.send(message);

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
@@ -4,8 +4,6 @@ import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
 
-import java.util.Collections;
-
 @ProcessingGroup(KafkaSendingEventHandler.GROUP)
 public class KafkaSendingEventHandler {
 
@@ -19,6 +17,6 @@ public class KafkaSendingEventHandler {
 
     @EventHandler
     public <T> void handle(EventMessage<T> message) {
-        kafkaPublisher.send(Collections.singletonList(message));
+        kafkaPublisher.send(message);
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
@@ -3,13 +3,13 @@ package org.axonframework.extensions.kafka.eventhandling.producer;
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
-import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 
-@Component
-@ProcessingGroup("axon.kafka.event")
+@ProcessingGroup(KafkaSendingEventHandler.GROUP)
 public class KafkaSendingEventHandler {
+
+    public static final String GROUP = "axon.kafka.event";
 
     private final KafkaPublisher kafkaPublisher;
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
@@ -1,0 +1,24 @@
+package org.axonframework.extensions.kafka.eventhandling.producer;
+
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.axonframework.eventhandling.EventMessage;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+@ProcessingGroup("axon.kafka.event")
+public class KafkaSendingEventHandler {
+
+    private final KafkaPublisher kafkaPublisher;
+
+    public KafkaSendingEventHandler(KafkaPublisher kafkaPublisher) {
+        this.kafkaPublisher = kafkaPublisher;
+    }
+
+    @EventHandler
+    public <T> void handle(EventMessage<T> message) {
+        kafkaPublisher.send(Collections.singletonList(message));
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright (c) 2010-2018. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.producer;
 
 import org.axonframework.config.ProcessingGroup;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.eventhandling.EventMessage;
 
+@SuppressWarnings("UNUSED")
 @ProcessingGroup(KafkaSendingEventHandler.GROUP)
 public class KafkaSendingEventHandler {
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaSendingEventHandler.java
@@ -27,6 +27,9 @@ import org.axonframework.eventhandling.EventMessage;
  * taking the EventProcessor Mode into account.
  * </p>
  * This class is not intended to be neither sub-classed nor instantiated by the end user of the extension.
+ *
+ * @author Simon Zambrovski
+ * @since 4.0.1
  */
 @SuppressWarnings("UNUSED")
 @ProcessingGroup(KafkaSendingEventHandler.GROUP)

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -18,6 +18,8 @@ package org.axonframework.extensions.kafka.eventhandling;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.axonframework.common.stream.BlockingStream;
+import org.axonframework.config.Configurer;
+import org.axonframework.config.DefaultConfigurer;
 import org.axonframework.eventhandling.EventBus;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.eventhandling.TrackedEventMessage;
@@ -27,9 +29,12 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumer
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
 import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaMessageSource;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaPublisher;
+import org.axonframework.extensions.kafka.eventhandling.producer.KafkaSendingEventHandler;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
@@ -40,40 +45,67 @@ import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.axonframework.extensions.kafka.eventhandling.ConsumerConfigUtil.minimal;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringRunner.class)
 @DirtiesContext
-@EmbeddedKafka(topics = {"integration"}, partitions = 5, controlledShutdown = true)
+@EmbeddedKafka(topics = { "integration" }, partitions = 5, controlledShutdown = true)
 public class KafkaIntegrationTest {
 
     @Autowired
     private KafkaEmbedded kafka;
+
+    private Configurer configurer = DefaultConfigurer.defaultConfiguration();
+
     private EventBus eventBus;
+    private ProducerFactory<String, byte[]> producerFactory;
+    private KafkaPublisher<String, byte[]> publisher;
+    private Fetcher fetcher;
+
+    @Before
+    public void setup() {
+        producerFactory = ProducerConfigUtil.ackProducerFactory(kafka, ByteArraySerializer.class);
+        publisher = KafkaPublisher.<String, byte[]>builder()
+            .producerFactory(producerFactory)
+            .topic("integration")
+            .build();
+        KafkaSendingEventHandler sender = new KafkaSendingEventHandler(publisher);
+        // event processor for listening to event bus and writing to kafka
+        configurer.eventProcessing(eventProcessingConfigurer -> eventProcessingConfigurer.registerEventHandler(c -> sender));
+
+        ConsumerFactory<String, byte[]> consumerFactory =
+            new DefaultConsumerFactory<>(minimal(kafka, "consumer1", ByteArrayDeserializer.class));
+
+        fetcher = AsyncFetcher.<String, byte[]>builder()
+            .consumerFactory(consumerFactory)
+            .topic("integration")
+            .pollTimeout(300, TimeUnit.MILLISECONDS)
+            .build();
+
+        // event bus
+        eventBus = SimpleEventBus.builder().build();
+        configurer.configureEventBus(configuration -> eventBus);
+
+        configurer.start();
+    }
+
+    @After
+    public void shutdown() {
+        producerFactory.shutDown();
+        fetcher.shutdown();
+        publisher.shutDown();
+    }
 
     @Test
     public void testPublishAndReadMessages() throws Exception {
-        eventBus = SimpleEventBus.builder().build();
-        ProducerFactory<String, byte[]> producerFactory =
-                ProducerConfigUtil.ackProducerFactory(kafka, ByteArraySerializer.class);
-        KafkaPublisher<String, byte[]> publisher = KafkaPublisher.<String, byte[]>builder()
-                .messageSource(eventBus)
-                .producerFactory(producerFactory)
-                .topic("integration")
-                .build();
-        publisher.start();
-        ConsumerFactory<String, byte[]> consumerFactory =
-                new DefaultConsumerFactory<>(minimal(kafka, "consumer1", ByteArrayDeserializer.class));
 
-        Fetcher fetcher = AsyncFetcher.<String, byte[]>builder()
-                .consumerFactory(consumerFactory)
-                .topic("integration")
-                .pollTimeout(300, TimeUnit.MILLISECONDS)
-                .build();
+
         KafkaMessageSource messageSource = new KafkaMessageSource(fetcher);
         BlockingStream<TrackedEventMessage<?>> stream1 = messageSource.openStream(null);
         stream1.close();
         BlockingStream<TrackedEventMessage<?>> stream2 = messageSource.openStream(null);
+
         eventBus.publish(asEventMessage("test"));
 
         // the consumer may need some time to start
@@ -82,8 +114,5 @@ public class KafkaIntegrationTest {
         assertNotNull(actual);
 
         stream2.close();
-        producerFactory.shutDown();
-        fetcher.shutdown();
-        publisher.shutDown();
     }
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -64,7 +64,7 @@ public class KafkaIntegrationTest {
     private Fetcher fetcher;
 
     @Before
-    public void setup() {
+    public void setupComponents() {
         producerFactory = ProducerConfigUtil.ackProducerFactory(kafka, ByteArraySerializer.class);
         publisher = KafkaPublisher.<String, byte[]>builder()
             .producerFactory(producerFactory)

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTests.java
@@ -130,12 +130,11 @@ public class FetchEventsTaskTests {
                               -1, null);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testTaskExecution_StartingThreadAndInterrupt_ShouldNotCauseAnyException() {
         SortedKafkaMessageBuffer<KafkaEventMessage> buffer = new SortedKafkaMessageBuffer<>(TOTAL_MESSAGES);
         KafkaMessageConverter<String, String> converter = new AsyncFetcherTests.ValueConverter();
-        FetchEventsTask testSubject = new FetchEventsTask<>(consumer(),
+        FetchEventsTask<String, String> testSubject = new FetchEventsTask<>(consumer(),
                                                             emptyToken(),
                                                             buffer,
                                                             converter,

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/SortedKafkaMessageBufferTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/SortedKafkaMessageBufferTests.java
@@ -43,6 +43,7 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
  *
  * @author Nakul Mishra.
  */
+@SuppressWarnings("ALL")
 public class SortedKafkaMessageBufferTests extends JSR166TestCase {
 
     public void testCreateBuffer_WithNonPositiveCapacity() {

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryTests.java
@@ -21,8 +21,9 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.axonframework.common.AxonConfigurationException;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
@@ -42,7 +43,6 @@ import static org.axonframework.extensions.kafka.eventhandling.ProducerConfigUti
 import static org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode.NONE;
 import static org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode.TRANSACTIONAL;
 import static org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory.builder;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 /**
@@ -53,11 +53,12 @@ import static org.mockito.Mockito.*;
 @RunWith(SpringRunner.class)
 @DirtiesContext
 @EmbeddedKafka(topics = {
-        "testProducerCreation",
-        "testSendingMessagesUsingMultipleProducers",
-        "testSendingMessagesUsingMultipleTransactionalProducers",
-        "testUsingCallbackWhilePublishingMessages",
-        "testTransactionalProducerBehaviorOnCommittingAnAbortedTransaction"}, count = 3)
+    "testProducerCreation",
+    "testSendingMessagesUsingMultipleProducers",
+    "testSendingMessagesUsingMultipleTransactionalProducers",
+    "testUsingCallbackWhilePublishingMessages",
+    "testTransactionalProducerBehaviorOnCommittingAnAbortedTransaction"
+}, count = 3)
 public class DefaultProducerFactoryTests {
 
     @Autowired
@@ -128,8 +129,9 @@ public class DefaultProducerFactoryTests {
 
     @Test
     public void testTransactionalProducerCreation() {
-        Assume.assumeFalse("Transactional producers not supported on Windows",
-                           System.getProperty("os.name").contains("Windows"));
+        Assume.assumeFalse(
+            "Transactional producers not supported on Windows",
+            System.getProperty("os.name").contains("Windows"));
 
         ProducerFactory<String, String> pf = txnProducerFactory(kafka, "xyz");
         Producer<String, String> producer = pf.createProducer();
@@ -154,7 +156,7 @@ public class DefaultProducerFactoryTests {
 
     @Test
     public void testSendingMessages_UsingMultipleTransactionalProducers()
-            throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException {
         ProducerFactory<String, String> pf = txnProducerFactory(kafka, "xyz");
         List<Producer<String, String>> producers = new ArrayList<>();
         List<Future<RecordMetadata>> results = new ArrayList<>();
@@ -172,8 +174,9 @@ public class DefaultProducerFactoryTests {
 
     @Test(expected = KafkaException.class)
     public void testTransactionalProducerBehavior_OnCommittingAnAbortedTransaction() {
-        Assume.assumeFalse("Transactional producers not supported on Windows",
-                           System.getProperty("os.name").contains("Windows"));
+        Assume.assumeFalse(
+            "Transactional producers not supported on Windows",
+            System.getProperty("os.name").contains("Windows"));
 
         ProducerFactory<String, String> pf = txnProducerFactory(kafka, "xyz");
         Producer<String, String> producer = pf.createProducer();
@@ -189,8 +192,9 @@ public class DefaultProducerFactoryTests {
 
     @Test(expected = KafkaException.class)
     public void testTransactionalProducerBehavior_OnSendingOffsetsWhenTransactionIsClosed() {
-        Assume.assumeFalse("Transactional producers not supported on Windows",
-                           System.getProperty("os.name").contains("Windows"));
+        Assume.assumeFalse(
+            "Transactional producers not supported on Windows",
+            System.getProperty("os.name").contains("Windows"));
         ProducerFactory<String, String> pf = txnProducerFactory(kafka, "xyz");
         Producer<String, String> producer = pf.createProducer();
         producer.beginTransaction();
@@ -203,10 +207,10 @@ public class DefaultProducerFactoryTests {
     @Test
     public void testClosingProducer_ShouldReturnItToCache() {
         ProducerFactory<Object, Object> pf = builder()
-                .producerCacheSize(2)
-                .configuration(minimalTransactional(kafka))
-                .transactionalIdPrefix("cache")
-                .build();
+            .producerCacheSize(2)
+            .configuration(minimalTransactional(kafka))
+            .transactionalIdPrefix("cache")
+            .build();
         Producer<Object, Object> first = pf.createProducer();
         first.close();
         Producer<Object, Object> second = pf.createProducer();
@@ -242,7 +246,7 @@ public class DefaultProducerFactoryTests {
     }
 
     private static void assertOffsets(List<Future<RecordMetadata>> results)
-            throws InterruptedException, ExecutionException {
+        throws InterruptedException, ExecutionException {
         for (Future<RecordMetadata> result : results) {
             assertThat(result.get().offset()).isGreaterThanOrEqualTo(0);
         }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherBuilderTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherBuilderTests.java
@@ -27,11 +27,6 @@ import org.junit.*;
 public class KafkaPublisherBuilderTests {
 
     @Test(expected = AxonConfigurationException.class)
-    public void testConfiguringInvalidMessageSource() {
-        KafkaPublisher.builder().messageSource(null);
-    }
-
-    @Test(expected = AxonConfigurationException.class)
     public void testConfiguringInvalidProducerFactory() {
         KafkaPublisher.builder().producerFactory(null).build();
     }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
@@ -320,15 +320,12 @@ public class KafkaPublisherTests {
                                             .serializer(XStreamSerializer.builder().build())
                                             .build();
         KafkaPublisher<?, ?> testSubject = KafkaPublisher.<String, byte[]>builder()
-                .messageSource(eventBus)
                 .producerFactory(producerFactory)
                 .messageConverter(messageConverter)
                 .messageMonitor(monitor)
                 .topic(topic)
                 .publisherAckTimeout(1000)
                 .build();
-
-        testSubject.start();
         return testSubject;
     }
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
@@ -22,6 +22,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.axonframework.config.Configurer;
+import org.axonframework.config.DefaultConfigurer;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.SimpleEventBus;
 import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
@@ -33,8 +35,13 @@ import org.axonframework.messaging.unitofwork.DefaultUnitOfWork;
 import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
@@ -57,7 +64,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.extensions.kafka.eventhandling.ConsumerConfigUtil.transactionalConsumerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.ProducerConfigUtil.ackProducerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.ProducerConfigUtil.txnProducerFactory;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 /**
@@ -66,13 +74,14 @@ import static org.mockito.Mockito.*;
  * @author Nakul Mishra
  */
 
-@EmbeddedKafka(topics = {"testPublishMessagesWithAckMode_NoUnitOfWork_ShouldBePublishedAndReadSuccessfully",
-        "testPublishMessagesWithTransactionalMode_NoUnitOfWork_ShouldBePublishedAndReadSuccessfully",
-        "testSendMessagesAck_UnitOfWork",
-        "testSendMessage_UnitOfWork",
-        "testShouldNotPublishEventsWhenKafkaTransactionCannotBeStarted",
-        "testShouldNotPublishEventsWhenKafkaTransactionCannotBeCommitted",
-        "testSendMessage_WithKafkaTransactionRollback"
+@EmbeddedKafka(topics = {
+    "testPublishMessagesWithAckMode_NoUnitOfWork_ShouldBePublishedAndReadSuccessfully",
+    "testPublishMessagesWithTransactionalMode_NoUnitOfWork_ShouldBePublishedAndReadSuccessfully",
+    "testSendMessagesAck_UnitOfWork",
+    "testSendMessage_UnitOfWork",
+    "testShouldNotPublishEventsWhenKafkaTransactionCannotBeStarted",
+    "testShouldNotPublishEventsWhenKafkaTransactionCannotBeCommitted",
+    "testSendMessage_WithKafkaTransactionRollback"
 }, count = 3)
 @RunWith(SpringRunner.class)
 @DirtiesContext
@@ -82,11 +91,16 @@ public class KafkaPublisherTests {
     private KafkaEmbedded kafka;
     private SimpleEventBus eventBus;
     private MessageCollector monitor;
+    private Configurer configurer;
 
     @Before
     public void setUp() {
+
+        this.configurer = DefaultConfigurer.defaultConfiguration();
         this.eventBus = SimpleEventBus.builder().build();
         this.monitor = new MessageCollector();
+
+        configurer.configureEventBus(configuration -> eventBus);
     }
 
     @Test
@@ -148,8 +162,9 @@ public class KafkaPublisherTests {
 
     @Test
     public void testPublishMessagesWithTransactionalMode_NoUnitOfWork_ShouldBePublishedAndReadSuccessfully() {
-        Assume.assumeFalse("Transactional producers not supported on Windows",
-                           System.getProperty("os.name").contains("Windows"));
+        Assume.assumeFalse(
+            "Transactional producers not supported on Windows",
+            System.getProperty("os.name").contains("Windows"));
 
         String topic = "testPublishMessagesWithTransactionalMode_NoUnitOfWork_ShouldBePublishedAndReadSuccessfully";
         ProducerFactory<String, byte[]> producerFactory = txnProducerFactory(kafka, "foo", ByteArraySerializer.class);
@@ -190,8 +205,9 @@ public class KafkaPublisherTests {
 
     @Test
     public void testPublishMessagesWithTransactionalMode_UnitOfWork_ShouldBePublishedAndReadSuccessfully() {
-        Assume.assumeFalse("Transactional producers not supported on Windows",
-                           System.getProperty("os.name").contains("Windows"));
+        Assume.assumeFalse(
+            "Transactional producers not supported on Windows",
+            System.getProperty("os.name").contains("Windows"));
 
         String topic = "testPublishMessagesWithTransactionalMode_UnitOfWork_ShouldBePublishedAndReadSuccessfully";
         ProducerFactory<String, byte[]> producerFactory = txnProducerFactory(kafka, "foo", ByteArraySerializer.class);
@@ -232,6 +248,8 @@ public class KafkaPublisherTests {
         cleanup(producerFactory, testSubject, consumer);
     }
 
+    // FIXME: try to fix this.
+    @Ignore
     @SuppressWarnings("unchecked")
     @Test(expected = EventPublicationFailedException.class)
     public void testPublishMessages_KafkaTransactionCannotBeStarted_ShouldThrowAnException() {
@@ -243,6 +261,8 @@ public class KafkaPublisherTests {
         publishWithException(topic, testSubject, message);
     }
 
+    // FIXME: try to fix this.
+    @Ignore
     @SuppressWarnings("unchecked")
     @Test(expected = EventPublicationFailedException.class)
     public void testPublishMessage_KafkaTransactionCannotBeCommitted_ShouldThrowAnException() {
@@ -288,8 +308,8 @@ public class KafkaPublisherTests {
     }
 
     private static DefaultProducerFactory producerFactoryWithFencedExceptionOnAbort() {
-        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class);
-        Producer producer = mock(Producer.class);
+        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class, "FactoryForExceptionOnAbortTx");
+        Producer producer = mock(Producer.class, "ExceptionOnAbortTx");
         when(producerFactory.confirmationMode()).thenReturn(ConfirmationMode.TRANSACTIONAL);
         when(producerFactory.createProducer()).thenReturn(producer);
         doThrow(RuntimeException.class).when(producer).abortTransaction();
@@ -297,8 +317,8 @@ public class KafkaPublisherTests {
     }
 
     private static DefaultProducerFactory producerFactoryWithFencedExceptionOnBeginTransaction() {
-        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class);
-        Producer producer = mock(Producer.class);
+        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class, "FactoryForExceptionOnBeginTx");
+        Producer producer = mock(Producer.class, "ExceptionOnBeginTxMock");
         when(producerFactory.confirmationMode()).thenReturn(ConfirmationMode.TRANSACTIONAL);
         when(producerFactory.createProducer()).thenReturn(producer);
         doThrow(ProducerFencedException.class).when(producer).beginTransaction();
@@ -307,7 +327,7 @@ public class KafkaPublisherTests {
 
     private static DefaultProducerFactory producerFactoryWithFencedExceptionOnCommit() {
         DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class);
-        Producer producer = mock(Producer.class);
+        Producer producer = mock(Producer.class, "ExceptionOnCommitTxMock");
         when(producerFactory.confirmationMode()).thenReturn(ConfirmationMode.TRANSACTIONAL);
         when(producerFactory.createProducer()).thenReturn(producer);
         doThrow(ProducerFencedException.class).when(producer).commitTransaction();
@@ -316,30 +336,35 @@ public class KafkaPublisherTests {
 
     private KafkaPublisher<?, ?> publisher(String topic, ProducerFactory<String, byte[]> producerFactory) {
         DefaultKafkaMessageConverter messageConverter =
-                DefaultKafkaMessageConverter.builder()
-                                            .serializer(XStreamSerializer.builder().build())
-                                            .build();
+            DefaultKafkaMessageConverter.builder()
+                                        .serializer(XStreamSerializer.builder().build())
+                                        .build();
         KafkaPublisher<?, ?> testSubject = KafkaPublisher.<String, byte[]>builder()
-                .producerFactory(producerFactory)
-                .messageConverter(messageConverter)
-                .messageMonitor(monitor)
-                .topic(topic)
-                .publisherAckTimeout(1000)
-                .build();
+            .producerFactory(producerFactory)
+            .messageConverter(messageConverter)
+            .messageMonitor(monitor)
+            .topic(topic)
+            .publisherAckTimeout(1000)
+            .build();
+        KafkaSendingEventHandler handler = new KafkaSendingEventHandler(testSubject);
+
+        configurer.eventProcessing(eventProcessingConfigurer -> eventProcessingConfigurer.registerEventHandler(c -> handler));
+        configurer.start();
         return testSubject;
     }
 
     private Consumer<?, ?> consumer(String topic) {
         Consumer<?, ?> consumer = transactionalConsumerFactory(
-                kafka, topic, ByteArrayDeserializer.class
+            kafka, topic, ByteArrayDeserializer.class
         ).createConsumer();
         consumer.subscribe(Collections.singleton(topic));
         return consumer;
     }
 
-    private static void cleanup(ProducerFactory<String, byte[]> producerFactory,
-                                KafkaPublisher<?, ?> testSubject,
-                                Consumer<?, ?> consumer) {
+    private static void cleanup(
+        ProducerFactory<String, byte[]> producerFactory,
+        KafkaPublisher<?, ?> testSubject,
+        Consumer<?, ?> consumer) {
         consumer.close();
         producerFactory.shutDown();
         testSubject.shutDown();
@@ -355,8 +380,9 @@ public class KafkaPublisherTests {
         return new GenericDomainEventMessage<>("Stub", aggregateId, 1L, "Payload", MetaData.with("key", "value"));
     }
 
-    private void publishWithException(String topic, KafkaPublisher<?, ?> testSubject,
-                                      GenericDomainEventMessage<String> message) {
+    private void publishWithException(
+        String topic, KafkaPublisher<?, ?> testSubject,
+        GenericDomainEventMessage<String> message) {
         try {
             UnitOfWork<?> uow = DefaultUnitOfWork.startAndGet(message);
             eventBus.publish(message);

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
@@ -51,8 +51,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTests.java
@@ -248,8 +248,6 @@ public class KafkaPublisherTests {
         cleanup(producerFactory, testSubject, consumer);
     }
 
-    // FIXME: try to fix this.
-    @Ignore
     @SuppressWarnings("unchecked")
     @Test(expected = EventPublicationFailedException.class)
     public void testPublishMessages_KafkaTransactionCannotBeStarted_ShouldThrowAnException() {
@@ -261,8 +259,6 @@ public class KafkaPublisherTests {
         publishWithException(topic, testSubject, message);
     }
 
-    // FIXME: try to fix this.
-    @Ignore
     @SuppressWarnings("unchecked")
     @Test(expected = EventPublicationFailedException.class)
     public void testPublishMessage_KafkaTransactionCannotBeCommitted_ShouldThrowAnException() {

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     </profiles>
 
     <properties>
-        <axon.version>4.2</axon.version>
+        <axon.version>4.0.1</axon.version>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
         <spring.version>5.1.5.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <module>kafka</module>
         <module>kafka-spring-boot-autoconfigure</module>
         <module>kafka-spring-boot-starter</module>
+        <module>kafka-axon-example</module>
     </modules>
     <packaging>pom</packaging>
 
@@ -107,11 +108,11 @@
     </profiles>
 
     <properties>
-        <axon.version>4.0.1</axon.version>
+        <axon.version>4.2</axon.version>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-        <spring.version>5.1.4.RELEASE</spring.version>
-        <spring.boot.version>2.1.2.RELEASE</spring.boot.version>
+        <spring.version>5.1.5.RELEASE</spring.version>
+        <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mockito.version>2.15.0</mockito.version>
         <kafka.version>1.0.0</kafka.version>


### PR DESCRIPTION
This PR closes #10.

Be default, the subscribing mode (as it is implemented now) is used. This can be changed by setting the variable `axon.kafka.event-processor-mode=TRACKING` (instead of default `axon.kafka.event-processor-mode=SUBSCRIBING`). In doing so, the event processor is registered as in tracking mode (this requires a configuration of a token store)  and will send the messages in a separate UoW.
