### PR TITLE
Fix KafkaTrackingToken#covers

### DIFF
--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaTrackingToken.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaTrackingToken.java
@@ -25,7 +25,6 @@ import org.axonframework.eventhandling.TrackingToken;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -100,10 +99,9 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
         Assert.isTrue(other instanceof KafkaTrackingToken, () -> "Incompatible token type provided.");
         KafkaTrackingToken otherToken = (KafkaTrackingToken) other;
 
-        long oldest = this.partitionPositions.values().stream().min(Comparator.naturalOrder()).orElse(0L);
-        return otherToken.partitionPositions.keySet().stream()
-                                            .allMatch(k -> this.partitionPositions.containsKey(k) ||
-                                                    otherToken.partitionPositions.get(k) < oldest);
+        return otherToken.partitionPositions
+                         .entrySet().stream()
+                         .allMatch(position -> position.getValue() <= this.partitionPositions.getOrDefault(position.getKey(), -1L));
     }
 
     public static boolean isEmpty(KafkaTrackingToken token) {

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaTrackingTokenTests.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaTrackingTokenTests.java
@@ -18,7 +18,6 @@ package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.common.TopicPartition;
 import org.assertj.core.util.Lists;
-import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaTrackingToken;
 import org.junit.*;
 
 import java.util.Collection;
@@ -196,6 +195,46 @@ public class KafkaTrackingTokenTests {
         }});
 
         assertThat(first.lowerBound(second)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testCoversRegression() {
+        KafkaTrackingToken first = KafkaTrackingToken.newInstance(new HashMap<Integer, Long>() {{
+            put(1, 2L);
+        }});
+
+        KafkaTrackingToken second = KafkaTrackingToken.newInstance(new HashMap<Integer, Long>() {{
+            put(0, 1L);
+        }});
+
+
+        assertThat(first.covers(second)).isFalse();
+    }
+
+    @Test
+    public void testRelationOfCoversAndUpperBounds() {
+        java.util.Random random = new java.util.Random();
+        for (int i = 0; i <= 10; i++) {
+            KafkaTrackingToken first = KafkaTrackingToken.newInstance(new HashMap<Integer, Long>() {{
+                put(random.nextInt(2), (long) random.nextInt(4) + 1);
+                put(random.nextInt(2), (long) random.nextInt(4) + 1);
+            }});
+
+            KafkaTrackingToken second = KafkaTrackingToken.newInstance(new HashMap<Integer, Long>() {{
+                put(random.nextInt(2), (long) random.nextInt(4) + 1);
+                put(random.nextInt(2), (long) random.nextInt(4) + 1);
+            }});
+
+            if (first.upperBound(second).equals(first)) {
+                assertThat(first.covers(second))
+                        .withFailMessage("The upper bound of first(%s) and second(%s) is not first, so first shouldn't cover second", first, second)
+                        .isTrue();
+            } else {
+                assertThat(first.covers(second))
+                        .withFailMessage("The upper bound of first(%s) and second(%s) is not first, so first shouldn't cover second", first, second)
+                        .isFalse();
+            }
+        }
     }
 
     private static KafkaTrackingToken nonEmptyToken() {


### PR DESCRIPTION
Hi I'm not sure if this is bug or not, but it seams that KafkaTrackingToken#covers is not quite correct and it's also untested.

Previously `covers` it returned false positives.

Add hand written property based test, it was help full in finding the
bug and write right current implementation