### PR TITLE
[#17 / #18 Part 2] Require provisioning of Consumer Group Id

### DIFF
--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -20,7 +20,7 @@ import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine
 import org.axonframework.extensions.kafka.KafkaProperties
-import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaMessageSource
+import org.axonframework.extensions.kafka.eventhandling.consumer.StreamableKafkaMessageSource
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
@@ -70,8 +70,8 @@ class KafkaAxonExampleApplication {
 
     @Autowired
     fun configureKafkaSourceForProcessingGroup(
-            configurer: EventProcessingConfigurer, kafkaMessageSource: KafkaMessageSource
+            configurer: EventProcessingConfigurer, streamableKafkaMessageSource: StreamableKafkaMessageSource
     ) {
-        configurer.registerTrackingEventProcessor("kafka-group") { kafkaMessageSource }
+        configurer.registerTrackingEventProcessor("kafka-group") { streamableKafkaMessageSource }
     }
 }

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -20,6 +20,7 @@ import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine
 import org.axonframework.extensions.kafka.KafkaProperties
+import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher
 import org.axonframework.extensions.kafka.eventhandling.consumer.StreamableKafkaMessageSource
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory
@@ -69,9 +70,11 @@ class KafkaAxonExampleApplication {
     }
 
     @Autowired
-    fun configureKafkaSourceForProcessingGroup(
-            configurer: EventProcessingConfigurer, streamableKafkaMessageSource: StreamableKafkaMessageSource
-    ) {
+    fun configureKafkaSourceForProcessingGroup(configurer: EventProcessingConfigurer, fetcher: Fetcher) {
+        val streamableKafkaMessageSource = StreamableKafkaMessageSource.builder()
+                .fetcher(fetcher)
+                .groupId("kafka-group")
+                .build()
         configurer.registerTrackingEventProcessor("kafka-group") { streamableKafkaMessageSource }
     }
 }

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -70,8 +70,7 @@ import java.util.Map;
 public class KafkaProperties {
 
     /**
-     * Comma-delimited list of host:port pairs to use for establishing the initial
-     * connection to the Kafka cluster.
+     * Comma-delimited list of host:port pairs to use for establishing the initial connection to the Kafka cluster.
      */
     private List<String> bootstrapServers = new ArrayList<>(Collections.singletonList("localhost:9092"));
 
@@ -88,8 +87,7 @@ public class KafkaProperties {
     /**
      * Controls the mode of event processor responsible for sending messages to Kafka.
      * <p>
-     * Depending on this, different error handling behaviours are taken in case of
-     * any errors during Kafka publishing.
+     * Depending on this, different error handling behaviours are taken in case of any errors during Kafka publishing.
      * </p>
      * <p>
      * Possible values are "SUBSCRIBING" (default) and "TRACKING".
@@ -248,7 +246,8 @@ public class KafkaProperties {
         private final Ssl ssl = new Ssl();
 
         /**
-         * Frequency in milliseconds that the consumer offsets are auto-committed to Kafka if 'enable.auto.commit' true.
+         * Frequency in milliseconds that the consumer offsets are auto-committed to Kafka if 'enable.auto.commit'
+         * true.
          */
         private Integer autoCommitInterval;
 
@@ -283,11 +282,6 @@ public class KafkaProperties {
          * Minimum amount of data the server should return for a fetch request in bytes.
          */
         private Integer fetchMinSize;
-
-        /**
-         * Unique string that identifies the consumer group this consumer belongs to.
-         */
-        private String groupId;
 
         /**
          * Expected time in milliseconds between heartbeats to the consumer coordinator.
@@ -374,14 +368,6 @@ public class KafkaProperties {
             this.fetchMinSize = fetchMinSize;
         }
 
-        public String getGroupId() {
-            return this.groupId;
-        }
-
-        public void setGroupId(String groupId) {
-            this.groupId = groupId;
-        }
-
         public Integer getHeartbeatInterval() {
             return this.heartbeatInterval;
         }
@@ -442,9 +428,6 @@ public class KafkaProperties {
             if (this.fetchMinSize != null) {
                 properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, this.fetchMinSize);
             }
-            if (this.groupId != null) {
-                properties.put(ConsumerConfig.GROUP_ID_CONFIG, this.groupId);
-            }
             if (this.heartbeatInterval != null) {
                 properties.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, this.heartbeatInterval);
             }
@@ -503,9 +486,9 @@ public class KafkaProperties {
     public static class Fetcher {
 
         /**
-         * The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
-         * If 0, returns immediately with any records that are available currently in the buffer, else returns empty.
-         * Must not be negative.
+         * The time, in milliseconds, spent waiting in poll if data is not available in the buffer. If 0, returns
+         * immediately with any records that are available currently in the buffer, else returns empty. Must not be
+         * negative.
          *
          * @see KafkaConsumer#poll(Duration)
          */

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.AsyncFetcher;
 import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
-import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaMessageSource;
 import org.axonframework.extensions.kafka.eventhandling.consumer.SortedKafkaMessageBuffer;
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode;
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory;
@@ -144,7 +143,6 @@ public class KafkaAutoConfiguration {
 
     @Bean("axonKafkaConsumerFactory")
     @ConditionalOnMissingBean
-    @ConditionalOnProperty("axon.kafka.consumer.group-id")
     public ConsumerFactory<String, byte[]> kafkaConsumerFactory() {
         return new DefaultConsumerFactory<>(properties.buildConsumerProperties());
     }
@@ -161,12 +159,5 @@ public class KafkaAutoConfiguration {
                 .topic(properties.getDefaultTopic())
                 .pollTimeout(properties.getFetcher().getPollTimeout())
                 .build();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @ConditionalOnBean(ConsumerFactory.class)
-    public KafkaMessageSource kafkaMessageSource(Fetcher kafkaFetcher) {
-        return new KafkaMessageSource(kafkaFetcher);
     }
 }

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTest.java
@@ -86,7 +86,6 @@ public class KafkaAutoConfigurationTest {
             assertThat(context.getBeanNamesForType(ConsumerFactory.class)).hasSize(1);
             assertThat(context.getBeanNamesForType(KafkaPublisher.class)).hasSize(1);
             assertThat(context.getBeanNamesForType(Fetcher.class)).hasSize(1);
-            assertThat(context.getBeanNamesForType(KafkaMessageSource.class)).hasSize(1);
             assertThat(context.getBeanNamesForType(KafkaMessageConverter.class)).hasSize(1);
 
             // Producer assertions
@@ -120,7 +119,6 @@ public class KafkaAutoConfigurationTest {
             assertThat(consumerConfigs.get(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG)).isNull();
             assertThat(consumerConfigs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG)).isNull();
             assertThat(consumerConfigs.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isNull();
-            assertThat(consumerConfigs.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("bar");
             assertThat(consumerConfigs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)).isNull();
             assertThat(consumerConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
                     .isEqualTo(StringDeserializer.class);
@@ -162,7 +160,6 @@ public class KafkaAutoConfigurationTest {
             // Required bean assertions
             assertThat(context.getBeanNamesForType(ConsumerFactory.class)).hasSize(1);
             assertThat(context.getBeanNamesForType(Fetcher.class)).hasSize(1);
-            assertThat(context.getBeanNamesForType(KafkaMessageSource.class)).hasSize(1);
             assertThat(context.getBeanNamesForType(KafkaMessageConverter.class)).hasSize(1);
 
             // Consumer assertions

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTest.java
@@ -35,7 +35,6 @@ import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
-import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaMessageSource;
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode;
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher;
@@ -78,8 +77,7 @@ public class KafkaAutoConfigurationTest {
         this.contextRunner.withUserConfiguration(TestConfiguration.class)
                           .withPropertyValues(
                                   "axon.kafka.default-topic=testTopic",
-                                  "axon.kafka.producer.transaction-id-prefix=foo",
-                                  "axon.kafka.consumer.group-id=bar"
+                                  "axon.kafka.producer.transaction-id-prefix=foo"
                           ).run(context -> {
             // Required bean assertions
             assertThat(context.getBeanNamesForType(ProducerFactory.class)).hasSize(1);
@@ -132,7 +130,6 @@ public class KafkaAutoConfigurationTest {
         this.contextRunner.withUserConfiguration(TestConfiguration.class)
                           .withPropertyValues(
                                   "axon.kafka.default-topic=testTopic",
-                                  "axon.kafka.consumer.group-id=bar",
                                   // Overrides 'axon.kafka.bootstrap-servers'
                                   "axon.kafka.bootstrap-servers=foo:1234",
                                   "axon.kafka.properties.foo=bar",
@@ -181,7 +178,6 @@ public class KafkaAutoConfigurationTest {
             assertThat(configs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isEqualTo("earliest");
             assertThat(configs.get(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG)).isEqualTo(456);
             assertThat(configs.get(ConsumerConfig.FETCH_MIN_BYTES_CONFIG)).isEqualTo(789);
-            assertThat(configs.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("bar");
             assertThat(configs.get(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)).isEqualTo(234);
             assertThat(configs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG)).isEqualTo(LongDeserializer.class);
             assertThat(configs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
@@ -251,7 +247,6 @@ public class KafkaAutoConfigurationTest {
                                   // Minimal Required Properties
                                   "axon.kafka.default-topic=testTopic",
                                   "axon.kafka.producer.transaction-id-prefix=foo",
-                                  "axon.kafka.consumer.group-id=bar",
                                   // Event Handling Mode
                                   "axon.kafka.event-processor-mode=TRACKING"
                           ).run(context -> {
@@ -277,7 +272,6 @@ public class KafkaAutoConfigurationTest {
                                   // Minimal Required Properties
                                   "axon.kafka.default-topic=testTopic",
                                   "axon.kafka.producer.transaction-id-prefix=foo",
-                                  "axon.kafka.consumer.group-id=bar",
                                   // Event Handling Mode
                                   "axon.kafka.event-processor-mode=SUBSCRIBING"
                           ).run(context -> {

--- a/kafka-spring-boot-autoconfigure/src/test/resources/log4j.properties
+++ b/kafka-spring-boot-autoconfigure/src/test/resources/log4j.properties
@@ -20,3 +20,4 @@ log4j.appender.Stdout.layout.conversionPattern=%d [%t] %-5p %-30.30c{1} %x - %m%
 log4j.rootLogger=INFO,Stdout
 
 log4j.logger.org.axonframework=INFO
+log4j.logger.org.axonframework.serialization.ChainingConverter=OFF

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerFactory.java
@@ -31,9 +31,9 @@ import org.apache.kafka.clients.consumer.Consumer;
 public interface ConsumerFactory<K, V> {
 
     /**
-     * Create a {@link Consumer}.
+     * Create a {@link Consumer} that should be part of the Consumer Group with the given {@code groupId}.
      *
-     * @return a {@link Consumer}
+     * @return a {@link Consumer} which is part of Consumer Group with the given {@code groupId}
      */
-    Consumer<K, V> createConsumer();
+    Consumer<K, V> createConsumer(String groupId);
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactory.java
@@ -18,16 +18,19 @@ package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * The {@link ConsumerFactory} implementation to produce a new {@link Consumer} instance. On each invocation of
- * {@link #createConsumer()} a new instance will be created based on the supplied {@code configuration} properties.
+ * The {@link ConsumerFactory} implementation to produce a new {@link Consumer} instance. On each invocation of {@link
+ * #createConsumer(String)} a new instance will be created based on the supplied {@code configuration} properties.
  *
  * @param <K> the key type of a build {@link Consumer} instance
  * @param <V> the value type of a build {@link Consumer} instance
@@ -37,22 +40,31 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
  */
 public class DefaultConsumerFactory<K, V> implements ConsumerFactory<K, V> {
 
-    private final Map<String, Object> configuration;
+    private static final Logger logger = LoggerFactory.getLogger(DefaultConsumerFactory.class);
+
+    private final Map<String, Object> consumerConfiguration;
 
     /**
-     * Build a default {@link ConsumerFactory} which uses the provided {@code configuration} to build it's
-     * {@link Consumer}s.
+     * Build a default {@link ConsumerFactory} which uses the provided {@code configuration} to build it's {@link
+     * Consumer}s.
      *
-     * @param configuration a {@link Map} containing the configuration for the {@link Consumer}s this factory builds
+     * @param consumerConfiguration a {@link Map} containing the configuration for the {@link Consumer}s this factory
+     *                              builds
      */
-    public DefaultConsumerFactory(Map<String, Object> configuration) {
-        assertNonNull(configuration, "The configuration may not be null");
-        this.configuration = new HashMap<>(configuration);
+    public DefaultConsumerFactory(Map<String, Object> consumerConfiguration) {
+        assertNonNull(consumerConfiguration, "The configuration may not be null");
+        this.consumerConfiguration = new HashMap<>(consumerConfiguration);
     }
 
     @Override
-    public Consumer<K, V> createConsumer() {
-        return new KafkaConsumer<>(this.configuration);
+    public Consumer<K, V> createConsumer(String groupId) {
+        if (this.consumerConfiguration.remove(GROUP_ID_CONFIG) != null) {
+            logger.warn("Found a global {} whilst it is required to be provided consciously", GROUP_ID_CONFIG);
+        }
+
+        Map<String, Object> consumerConfiguration = new HashMap<>(this.consumerConfiguration);
+        consumerConfiguration.put(GROUP_ID_CONFIG, groupId);
+        return new KafkaConsumer<>(consumerConfiguration);
     }
 
     /**
@@ -62,6 +74,6 @@ public class DefaultConsumerFactory<K, V> implements ConsumerFactory<K, V> {
      * @return a configuration {@link Map} used by this {@link ConsumerFactory} to build {@link Consumer}s
      */
     public Map<String, Object> configurationProperties() {
-        return Collections.unmodifiableMap(this.configuration);
+        return Collections.unmodifiableMap(this.consumerConfiguration);
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
@@ -30,10 +30,11 @@ public interface Fetcher {
     /**
      * Open a stream of messages, starting at the position indicated by the given {@code token}.
      *
-     * @param token the token representing positions of the partitions to start from
+     * @param token   the token representing positions of the partitions to start from
+     * @param groupId a {@link String} defining the Consumer Group id the fetcher should start Consumer instances in
      * @return a {@link BlockingStream} providing messages from Kafka
      */
-    BlockingStream<TrackedEventMessage<?>> start(KafkaTrackingToken token);
+    BlockingStream<TrackedEventMessage<?>> start(KafkaTrackingToken token, String groupId);
 
     /**
      * Shuts the fetcher down, closing any resources used by this fetcher.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageSource.java
@@ -16,13 +16,17 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingToken;
 import org.axonframework.messaging.StreamableMessageSource;
 
+import java.util.Objects;
+
 import static org.axonframework.common.Assert.isTrue;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.common.BuilderUtils.assertThat;
 
 /**
  * Implementation of the {@link StreamableMessageSource} that reads messages from a Kafka topic using the provided
@@ -35,15 +39,32 @@ import static org.axonframework.common.BuilderUtils.assertNonNull;
 public class KafkaMessageSource implements StreamableMessageSource<TrackedEventMessage<?>> {
 
     private final Fetcher fetcher;
+    private final String groupId;
 
     /**
-     * Initialize the source using the given {@code fetcher} to retrieve messages from a Kafka topic.
+     * Instantiate a Builder to be able to create a {@link KafkaMessageSource}.
+     * <p>
+     * The {@link Fetcher} and {@code groupId} are <b>hard requirements</b> and as such should be provided.
      *
-     * @param fetcher the {@link Fetcher} used to retrieve messages from a Kafka topic
+     * @return a Builder to be able to create an {@link KafkaMessageSource}
      */
-    public KafkaMessageSource(Fetcher fetcher) {
-        assertNonNull(fetcher, "Kafka message fetcher may not be null");
-        this.fetcher = fetcher;
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Instantiate a {@link KafkaMessageSource} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@link Fetcher} is not {@code null} and that the {@code groupId} is a non-empty {@link
+     * String}. An {@link AxonConfigurationException} is thrown if either of both is not the case.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link KafkaMessageSource} instance
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected KafkaMessageSource(Builder builder) {
+        builder.validate();
+        this.fetcher = builder.fetcher;
+        this.groupId = builder.groupId;
     }
 
     @SuppressWarnings("ConstantConditions") // Verified TrackingToken type through `Assert.isTrue` operation
@@ -53,6 +74,70 @@ public class KafkaMessageSource implements StreamableMessageSource<TrackedEventM
                 trackingToken == null || trackingToken instanceof KafkaTrackingToken,
                 () -> "Incompatible token type provided."
         );
-        return fetcher.start((KafkaTrackingToken) trackingToken);
+
+        return fetcher.start((KafkaTrackingToken) trackingToken, groupId);
+    }
+
+    /**
+     * Builder class to instantiate a {@link KafkaMessageSource}.
+     * <p>
+     * The {@link Fetcher} and {@code groupId} are <b>hard requirements</b> and as such should be provided.
+     */
+    public static class Builder {
+
+        private Fetcher fetcher;
+        private String groupId;
+
+        /**
+         * Sets the {@link Fetcher} used to fetch a {@link BlockingStream} of {@link TrackedEventMessage} instances.
+         *
+         * @param fetcher the {@link Fetcher} used to fetch a {@link BlockingStream} of {@link TrackedEventMessage}
+         *                instances
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder fetcher(Fetcher fetcher) {
+            assertNonNull(fetcher, "Fetcher may not be null");
+            this.fetcher = fetcher;
+            return this;
+        }
+
+        /**
+         * Sets the Consumer {@code groupId} from which a {@link BlockingStream} should retrieve its events from
+         *
+         * @param groupId a {@link String} defining the Consumer Group id from which a {@link BlockingStream} should
+         *                retrieve its events from
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder groupId(String groupId) {
+            assertThat(
+                    groupId, name -> Objects.nonNull(name) && !"".equals(name),
+                    "The groupId may not be null or empty"
+            );
+            this.groupId = groupId;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link KafkaMessageSource} as specified through this Builder.
+         *
+         * @return a {@link KafkaMessageSource} as specified through this Builder
+         */
+        public KafkaMessageSource build() {
+            return new KafkaMessageSource(this);
+        }
+
+        /**
+         * Validates whether the fields contained in this Builder are set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        @SuppressWarnings("WeakerAccess")
+        protected void validate() throws AxonConfigurationException {
+            assertNonNull(fetcher, "The Fetcher is a hard requirement and should be provided");
+            assertThat(groupId,
+                       name -> Objects.nonNull(name) && !"".equals(name),
+                       "The groupId may not be null or empty");
+        }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -36,32 +36,32 @@ import static org.axonframework.common.BuilderUtils.assertThat;
  * @author Steven van Beelen
  * @since 4.0
  */
-public class KafkaMessageSource implements StreamableMessageSource<TrackedEventMessage<?>> {
+public class StreamableKafkaMessageSource implements StreamableMessageSource<TrackedEventMessage<?>> {
 
     private final Fetcher fetcher;
     private final String groupId;
 
     /**
-     * Instantiate a Builder to be able to create a {@link KafkaMessageSource}.
+     * Instantiate a Builder to be able to create a {@link StreamableKafkaMessageSource}.
      * <p>
      * The {@link Fetcher} and {@code groupId} are <b>hard requirements</b> and as such should be provided.
      *
-     * @return a Builder to be able to create an {@link KafkaMessageSource}
+     * @return a Builder to be able to create an {@link StreamableKafkaMessageSource}
      */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Instantiate a {@link KafkaMessageSource} based on the fields contained in the {@link Builder}.
+     * Instantiate a {@link StreamableKafkaMessageSource} based on the fields contained in the {@link Builder}.
      * <p>
      * Will assert that the {@link Fetcher} is not {@code null} and that the {@code groupId} is a non-empty {@link
      * String}. An {@link AxonConfigurationException} is thrown if either of both is not the case.
      *
-     * @param builder the {@link Builder} used to instantiate a {@link KafkaMessageSource} instance
+     * @param builder the {@link Builder} used to instantiate a {@link StreamableKafkaMessageSource} instance
      */
     @SuppressWarnings("WeakerAccess")
-    protected KafkaMessageSource(Builder builder) {
+    protected StreamableKafkaMessageSource(Builder builder) {
         builder.validate();
         this.fetcher = builder.fetcher;
         this.groupId = builder.groupId;
@@ -79,7 +79,7 @@ public class KafkaMessageSource implements StreamableMessageSource<TrackedEventM
     }
 
     /**
-     * Builder class to instantiate a {@link KafkaMessageSource}.
+     * Builder class to instantiate a {@link StreamableKafkaMessageSource}.
      * <p>
      * The {@link Fetcher} and {@code groupId} are <b>hard requirements</b> and as such should be provided.
      */
@@ -118,12 +118,12 @@ public class KafkaMessageSource implements StreamableMessageSource<TrackedEventM
         }
 
         /**
-         * Initializes a {@link KafkaMessageSource} as specified through this Builder.
+         * Initializes a {@link StreamableKafkaMessageSource} as specified through this Builder.
          *
-         * @return a {@link KafkaMessageSource} as specified through this Builder
+         * @return a {@link StreamableKafkaMessageSource} as specified through this Builder
          */
-        public KafkaMessageSource build() {
-            return new KafkaMessageSource(this);
+        public StreamableKafkaMessageSource build() {
+            return new StreamableKafkaMessageSource(this);
         }
 
         /**

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -27,7 +27,7 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.AsyncFetcher;
 import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
-import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaMessageSource;
+import org.axonframework.extensions.kafka.eventhandling.consumer.StreamableKafkaMessageSource;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaPublisher;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
@@ -105,10 +105,10 @@ public class KafkaIntegrationTest {
 
     @Test
     public void testPublishAndReadMessages() throws Exception {
-        KafkaMessageSource messageSource = KafkaMessageSource.builder()
-                                                             .fetcher(fetcher)
-                                                             .groupId(DEFAULT_GROUP_ID)
-                                                             .build();
+        StreamableKafkaMessageSource messageSource = StreamableKafkaMessageSource.builder()
+                                                                                 .fetcher(fetcher)
+                                                                                 .groupId(DEFAULT_GROUP_ID)
+                                                                                 .build();
         BlockingStream<TrackedEventMessage<?>> stream1 = messageSource.openStream(null);
         stream1.close();
         BlockingStream<TrackedEventMessage<?>> stream2 = messageSource.openStream(null);

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -28,8 +28,8 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
 import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaMessageSource;
-import org.axonframework.extensions.kafka.eventhandling.producer.KafkaPublisher;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher;
+import org.axonframework.extensions.kafka.eventhandling.producer.KafkaPublisher;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
 import org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil;
 import org.junit.*;
@@ -43,6 +43,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.minimal;
 import static org.junit.Assert.*;
 
@@ -104,7 +105,10 @@ public class KafkaIntegrationTest {
 
     @Test
     public void testPublishAndReadMessages() throws Exception {
-        KafkaMessageSource messageSource = new KafkaMessageSource(fetcher);
+        KafkaMessageSource messageSource = KafkaMessageSource.builder()
+                                                             .fetcher(fetcher)
+                                                             .groupId(DEFAULT_GROUP_ID)
+                                                             .build();
         BlockingStream<TrackedEventMessage<?>> stream1 = messageSource.openStream(null);
         stream1.close();
         BlockingStream<TrackedEventMessage<?>> stream2 = messageSource.openStream(null);

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -82,7 +82,7 @@ public class KafkaIntegrationTest {
         );
 
         ConsumerFactory<String, byte[]> consumerFactory =
-                new DefaultConsumerFactory<>(minimal(kafkaBroker, "consumer1", ByteArrayDeserializer.class));
+                new DefaultConsumerFactory<>(minimal(kafkaBroker, ByteArrayDeserializer.class));
 
         fetcher = AsyncFetcher.<String, byte[]>builder()
                 .consumerFactory(consumerFactory)

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -72,7 +72,7 @@ public class AsyncFetcherTest {
     private static ConsumerFactory<String, String> mockConsumerFactory(String topic) {
         ConsumerFactory<String, String> consumerFactory = mock(ConsumerFactory.class);
         Consumer<String, String> consumer = mock(Consumer.class);
-        when(consumerFactory.createConsumer()).thenReturn(consumer);
+        when(consumerFactory.createConsumer(DEFAULT_GROUP_ID)).thenReturn(consumer);
 
         int partition = 0;
         Map<TopicPartition, List<ConsumerRecord<String, String>>> record = new HashMap<>();

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -46,12 +46,13 @@ import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.axonframework.extensions.kafka.eventhandling.consumer.AsyncFetcher.builder;
+import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.consumerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for {@link AsyncFetcher}.
+ * Tests for {@link AsyncFetcher}, asserting construction and utilization of the class.
  *
  * @author Nakul Mishra
  * @author Steven van Beelen
@@ -121,7 +122,7 @@ public class AsyncFetcherTest {
                 .pollTimeout(3000)
                 .build();
 
-        testSubject.start(null);
+        testSubject.start(null, DEFAULT_GROUP_ID);
 
         messageCounter.await();
 
@@ -152,7 +153,7 @@ public class AsyncFetcherTest {
         ProducerFactory<String, String> producerFactory = publishRecords(testTopic, p0, p1, p2, p3, p4);
         SortedKafkaMessageBuffer<KafkaEventMessage> testBuffer = new SortedKafkaMessageBuffer<>(expectedMessages);
         Fetcher testSubject = AsyncFetcher.<String, String>builder()
-                .consumerFactory(consumerFactory(kafkaBroker, testTopic))
+                .consumerFactory(consumerFactory(kafkaBroker))
                 .bufferFactory(() -> testBuffer)
                 .messageConverter(new ValueConverter())
                 .topic(testTopic)
@@ -167,7 +168,7 @@ public class AsyncFetcherTest {
         testPartitionPositions.put(3, 4L);
         testPartitionPositions.put(4, 0L);
         KafkaTrackingToken testStartToken = KafkaTrackingToken.newInstance(testPartitionPositions);
-        testSubject.start(testStartToken);
+        testSubject.start(testStartToken, DEFAULT_GROUP_ID);
 
         messageCounter.await();
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerUtilTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerUtilTest.java
@@ -39,12 +39,13 @@ import static java.util.Collections.emptyMap;
 import static kafka.utils.TestUtils.pollUntilAtLeastNumRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerUtil.seek;
+import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.consumerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
 import static org.springframework.kafka.test.utils.KafkaTestUtils.getRecords;
 
 /***
- * Tests for the {@link ConsumerUtil} class.
+ * Tests for the {@link ConsumerUtil} class asserting utilization of the class.
  *
  * @author Nakul Mishra
  * @author Steven van Beelen
@@ -69,10 +70,12 @@ public class ConsumerUtilTest {
     @Autowired
     private EmbeddedKafkaBroker kafkaBroker;
     private ProducerFactory<String, String> producerFactory;
+    private ConsumerFactory<String, String> consumerFactory;
 
     @Before
     public void setUp() {
         producerFactory = producerFactory(kafkaBroker);
+        consumerFactory = consumerFactory(kafkaBroker);
     }
 
     @After
@@ -92,7 +95,7 @@ public class ConsumerUtilTest {
         AtomicInteger recordCounter = new AtomicInteger();
         KafkaTrackingToken testToken = null;
 
-        Consumer<?, ?> testSubject = consumerFactory(kafkaBroker, topic).createConsumer();
+        Consumer<?, ?> testSubject = consumerFactory.createConsumer(DEFAULT_GROUP_ID);
         seek(topic, testSubject, testToken);
 
         getRecords(testSubject).forEach(record -> {
@@ -115,7 +118,7 @@ public class ConsumerUtilTest {
         AtomicInteger recordCounter = new AtomicInteger();
         KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(emptyMap());
 
-        Consumer<?, ?> testSubject = consumerFactory(kafkaBroker, topic).createConsumer();
+        Consumer<?, ?> testSubject = consumerFactory.createConsumer(DEFAULT_GROUP_ID);
         seek(topic, testSubject, testToken);
 
         getRecords(testSubject).forEach(record -> {
@@ -147,7 +150,7 @@ public class ConsumerUtilTest {
         //  their offsets will increase given the published number of `recordsPerPartitions`
         int numberOfRecordsToConsume = 26;
 
-        Consumer<?, ?> testSubject = consumerFactory(kafkaBroker, topic).createConsumer();
+        Consumer<?, ?> testSubject = consumerFactory.createConsumer(DEFAULT_GROUP_ID);
         seek(topic, testSubject, testToken);
 
         Seq<ConsumerRecord<byte[], byte[]>> resultRecords =
@@ -180,7 +183,7 @@ public class ConsumerUtilTest {
         //  their offsets will increase given the published number of `recordsPerPartitions`
         int numberOfRecordsToConsume = 26;
 
-        Consumer<?, ?> testSubject = consumerFactory(kafkaBroker, topic).createConsumer();
+        Consumer<?, ?> testSubject = consumerFactory.createConsumer(DEFAULT_GROUP_ID);
         seek(topic, testSubject, testToken);
 
         Seq<ConsumerRecord<byte[], byte[]>> resultRecords =

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
@@ -25,38 +25,38 @@ import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConf
 import static org.mockito.Mockito.*;
 
 /**
- * Tests for {@link KafkaMessageSource}, asserting construction and utilization of the class.
+ * Tests for {@link StreamableKafkaMessageSource}, asserting construction and utilization of the class.
  *
  * @author Nakul Mishra
  * @author Steven van Beelen
  */
-public class KafkaMessageSourceTest {
+public class StreamableKafkaMessageSourceTest {
 
     private Fetcher fetcher = mock(Fetcher.class);
 
-    private KafkaMessageSource testSubject;
+    private StreamableKafkaMessageSource testSubject;
 
     @Before
     public void setUp() {
-        testSubject = KafkaMessageSource.builder()
-                                        .fetcher(fetcher)
-                                        .groupId(DEFAULT_GROUP_ID)
-                                        .build();
+        testSubject = StreamableKafkaMessageSource.builder()
+                                                  .fetcher(fetcher)
+                                                  .groupId(DEFAULT_GROUP_ID)
+                                                  .build();
     }
 
     @Test(expected = AxonConfigurationException.class)
     public void testBuildingStreamableKafkaMessageSourceMissingRequiredFieldsShouldThrowAxonConfigurationException() {
-        KafkaMessageSource.builder().build();
+        StreamableKafkaMessageSource.builder().build();
     }
 
     @Test(expected = AxonConfigurationException.class)
     public void testBuildingStreamableKafkaMessageSourceUsingInvalidFetcherShouldThrowAxonConfigurationException() {
-        KafkaMessageSource.builder().fetcher(null);
+        StreamableKafkaMessageSource.builder().fetcher(null);
     }
 
     @Test(expected = AxonConfigurationException.class)
     public void testBuildingStreamableKafkaMessageSourceUsingInvalidGroupIdShouldThrowAxonConfigurationException() {
-        KafkaMessageSource.builder().groupId(null);
+        StreamableKafkaMessageSource.builder().groupId(null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/ConsumerConfigUtil.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/ConsumerConfigUtil.java
@@ -25,7 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Test utility for generating a {@link ConsumerConfig}.
+ * Test utility for generating a {@link org.apache.kafka.clients.consumer.Consumer} configuration map to be used in
+ * tests or an entire {@link ConsumerFactory} at once.
  *
  * @author Nakul Mishra
  * @author Steven van Beelen
@@ -33,7 +34,7 @@ import java.util.Map;
 public abstract class ConsumerConfigUtil {
 
     /**
-     *
+     * A default Consumer Group group id used for testing.
      */
     public static final String DEFAULT_GROUP_ID = "groupId";
 
@@ -41,37 +42,66 @@ public abstract class ConsumerConfigUtil {
         // Utility class
     }
 
+    /**
+     * Build a minimal, transactional {@link ConsumerFactory} to be used during testing only.
+     *
+     * @param kafkaBroker       the {@link EmbeddedKafkaBroker} used in the test case
+     * @param valueDeserializer a {@link Class} defining the type of value deserializer to be used
+     * @return a {@link ConsumerFactory} configured with the minimal properties based on the given {@code kafkaBroker}
+     * and {@code valueDeserializer}
+     */
     public static ConsumerFactory<String, Object> transactionalConsumerFactory(EmbeddedKafkaBroker kafkaBroker,
-                                                                               String groupName,
                                                                                Class valueDeserializer) {
-        return new DefaultConsumerFactory<>(minimalTransactional(kafkaBroker, groupName, valueDeserializer));
+        return new DefaultConsumerFactory<>(minimalTransactional(kafkaBroker, valueDeserializer));
     }
 
-    public static ConsumerFactory<String, String> consumerFactory(EmbeddedKafkaBroker kafkaBroker, String groupName) {
-        return new DefaultConsumerFactory<>(minimal(kafkaBroker, groupName));
-    }
-
-    public static Map<String, Object> minimalTransactional(EmbeddedKafkaBroker kafkaBroker,
-                                                           String groupName,
-                                                           Class valueDeserializer) {
-        Map<String, Object> configs = minimal(kafkaBroker, groupName, valueDeserializer);
+    /**
+     * Build a minimal, transactional, {@link org.apache.kafka.clients.consumer.Consumer} configuration {@link Map}
+     *
+     * @param kafkaBroker       the {@link EmbeddedKafkaBroker} used in the test case
+     * @param valueDeserializer a {@link Class} defining the type of value deserializer to be used
+     * @return a minimal, transactional, {@link org.apache.kafka.clients.consumer.Consumer} configuration {@link Map}
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static Map<String, Object> minimalTransactional(EmbeddedKafkaBroker kafkaBroker, Class valueDeserializer) {
+        Map<String, Object> configs = minimal(kafkaBroker, valueDeserializer);
         configs.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
         return configs;
     }
 
-    public static Map<String, Object> minimal(EmbeddedKafkaBroker kafkaBroker, String groupName) {
-        return minimal(kafkaBroker, groupName, StringDeserializer.class);
+    /**
+     * Build a minimal {@link ConsumerFactory} to be used during testing only.
+     *
+     * @param kafkaBroker the {@link EmbeddedKafkaBroker} used in the test case
+     * @return a {@link ConsumerFactory} configured with the minimal properties based on the given {@code kafkaBroker}
+     */
+    public static ConsumerFactory<String, String> consumerFactory(EmbeddedKafkaBroker kafkaBroker) {
+        return new DefaultConsumerFactory<>(minimal(kafkaBroker));
     }
 
-    public static Map<String, Object> minimal(EmbeddedKafkaBroker kafkaBroker,
-                                              String groupName,
-                                              Class valueDeserializer) {
+    /**
+     * Build a minimal {@link org.apache.kafka.clients.consumer.Consumer} configuration {@link Map}
+     *
+     * @param kafkaBroker the {@link EmbeddedKafkaBroker} used in the test case
+     * @return a minimal {@link org.apache.kafka.clients.consumer.Consumer} configuration {@link Map}
+     */
+    public static Map<String, Object> minimal(EmbeddedKafkaBroker kafkaBroker) {
+        return minimal(kafkaBroker, StringDeserializer.class);
+    }
+
+    /**
+     * Build a minimal {@link org.apache.kafka.clients.consumer.Consumer} configuration {@link Map}
+     *
+     * @param kafkaBroker       the {@link EmbeddedKafkaBroker} used in the test case
+     * @param valueDeserializer a {@link Class} defining the type of value deserializer to be used
+     * @return a minimal {@link org.apache.kafka.clients.consumer.Consumer} configuration {@link Map}
+     */
+    public static Map<String, Object> minimal(EmbeddedKafkaBroker kafkaBroker, Class valueDeserializer) {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker.getBrokersAsString());
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
         config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, groupName);
         return config;
     }
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/ConsumerConfigUtil.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/ConsumerConfigUtil.java
@@ -32,7 +32,12 @@ import java.util.Map;
  */
 public abstract class ConsumerConfigUtil {
 
-    public ConsumerConfigUtil() {
+    /**
+     *
+     */
+    public static final String DEFAULT_GROUP_ID = "groupId";
+
+    private ConsumerConfigUtil() {
         // Utility class
     }
 


### PR DESCRIPTION
This pull request ensure that a `groupId` should always be required upon creation of a Message Source. This firstly means adjustments in the existing `StreamableMessageSource` implementation tying in to part two of #18, but is also a requirement of #17.

Concretely, the `groupId` is enforced by the following two adjustments:

1. The `ConsumerFactory#createConsumer()` is adjusted to `ConsumerFactory#createConsumer(String)`
2. The `Fetcher#start(TrackingToken)` is adjusted to `Fetcher#start(TrackingToken, String)`

The first step ensure a Kafka `Consumer` cannot be created from within this extension without providing a Consumer `groupId`. This will break any usage of the factory which is not aware of the Consumer Group it is intended to start a `Consumer` for.

The second set makes it so that the `KafkaMessageSource` implementation is required to know in which `groupId` it should start a stream of events. This will make it so that a `TrackingEventProcessor` which desires to use the `KafkaMessageSource` can correctly configure it with a `groupId` corresponding to the processor-name/processing-group.

This PR partially resolves #18.