### PR TITLE
[#17 - Part 1] Adjust Fetcher to allow Tracking and Subscribing

### DIFF
--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -30,6 +30,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
+
 /**
  * Starting point.
  */

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -20,8 +20,8 @@ import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine
 import org.axonframework.extensions.kafka.KafkaProperties
-import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher
-import org.axonframework.extensions.kafka.eventhandling.consumer.StreamableKafkaMessageSource
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter
+import org.axonframework.extensions.kafka.eventhandling.consumer.*
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
@@ -58,7 +58,7 @@ class KafkaAxonExampleApplication {
     fun tokenStore() = InMemoryTokenStore()
 
     /**
-     * Creates a Kafka producer factory, using the Kakfa properties configured in resources/application.yml
+     * Creates a Kafka producer factory, using the Kafka properties configured in resources/application.yml
      */
     @Bean
     fun producerFactory(kafkaProperties: KafkaProperties): ProducerFactory<String, ByteArray>? {
@@ -70,10 +70,18 @@ class KafkaAxonExampleApplication {
     }
 
     @Autowired
-    fun configureKafkaSourceForProcessingGroup(configurer: EventProcessingConfigurer, fetcher: Fetcher) {
-        val streamableKafkaMessageSource = StreamableKafkaMessageSource.builder()
-                .fetcher(fetcher)
+    fun configureKafkaSourceForProcessingGroup(configurer: EventProcessingConfigurer,
+                                               kafkaProperties: KafkaProperties,
+                                               consumerFactory: ConsumerFactory<String, ByteArray>,
+                                               fetcher: Fetcher<KafkaEventMessage, String, ByteArray>,
+                                               kafkaMessageConverter: KafkaMessageConverter<String, ByteArray>) {
+        val streamableKafkaMessageSource = StreamableKafkaMessageSource.builder<String, ByteArray>()
+                .topic(kafkaProperties.defaultTopic)
                 .groupId("kafka-group")
+                .consumerFactory(consumerFactory)
+                .fetcher(fetcher)
+                .messageConverter(kafkaMessageConverter)
+                .bufferFactory { SortedKafkaMessageBuffer<KafkaEventMessage>(kafkaProperties.fetcher.bufferSize) }
                 .build()
         configurer.registerTrackingEventProcessor("kafka-group") { streamableKafkaMessageSource }
     }

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -73,7 +73,7 @@ class KafkaAxonExampleApplication {
     fun configureKafkaSourceForProcessingGroup(configurer: EventProcessingConfigurer,
                                                kafkaProperties: KafkaProperties,
                                                consumerFactory: ConsumerFactory<String, ByteArray>,
-                                               fetcher: Fetcher<KafkaEventMessage, String, ByteArray>,
+                                               fetcher: Fetcher<String, ByteArray, KafkaEventMessage>,
                                                kafkaMessageConverter: KafkaMessageConverter<String, ByteArray>) {
         val streamableKafkaMessageSource = StreamableKafkaMessageSource.builder<String, ByteArray>()
                 .topic(kafkaProperties.defaultTopic)

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2019. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,7 +30,6 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableScheduling
-
 /**
  * Starting point.
  */

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Map;
 
 import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
+
 /**
  * Auto configuration for the Axon Kafka Extension as an Event Message distribution solution.
  *
@@ -149,7 +150,7 @@ public class KafkaAutoConfiguration {
     @Bean(destroyMethod = "shutdown")
     public Fetcher kafkaFetcher() {
         return AsyncFetcher.builder()
-                .pollTimeout(properties.getFetcher().getPollTimeout())
-                .build();
+                           .pollTimeout(properties.getFetcher().getPollTimeout())
+                           .build();
     }
 }

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.AsyncFetcher;
 import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
-import org.axonframework.extensions.kafka.eventhandling.consumer.SortedKafkaMessageBuffer;
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode;
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher;
@@ -149,14 +148,8 @@ public class KafkaAutoConfiguration {
 
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutdown")
-    @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class})
-    public Fetcher kafkaFetcher(ConsumerFactory<String, byte[]> axonKafkaConsumerFactory,
-                                KafkaMessageConverter<String, byte[]> kafkaMessageConverter) {
+    public Fetcher kafkaFetcher() {
         return AsyncFetcher.<String, byte[]>builder()
-                .consumerFactory(axonKafkaConsumerFactory)
-                .bufferFactory(() -> new SortedKafkaMessageBuffer<>(properties.getFetcher().getBufferSize()))
-                .messageConverter(kafkaMessageConverter)
-                .topic(properties.getDefaultTopic())
                 .pollTimeout(properties.getFetcher().getPollTimeout())
                 .build();
     }

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -47,7 +47,6 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Map;
 
 import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
-
 /**
  * Auto configuration for the Axon Kafka Extension as an Event Message distribution solution.
  *

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -107,10 +107,10 @@ public class KafkaAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean({KafkaPublisher.class})
-    public KafkaEventPublisher kafkaEventPublisher(KafkaPublisher<String, byte[]> kafkaPublisher,
-                                                   KafkaProperties kafkaProperties,
-                                                   EventProcessingConfigurer eventProcessingConfigurer) {
-        KafkaEventPublisher kafkaEventPublisher =
+    public KafkaEventPublisher<String, byte[]> kafkaEventPublisher(KafkaPublisher<String, byte[]> kafkaPublisher,
+                                                                   KafkaProperties kafkaProperties,
+                                                                   EventProcessingConfigurer eventProcessingConfigurer) {
+        KafkaEventPublisher<String, byte[]> kafkaEventPublisher =
                 KafkaEventPublisher.<String, byte[]>builder().kafkaPublisher(kafkaPublisher).build();
 
         /*
@@ -148,7 +148,7 @@ public class KafkaAutoConfiguration {
 
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutdown")
-    public Fetcher kafkaFetcher() {
+    public Fetcher<?, ?, ?> kafkaFetcher() {
         return AsyncFetcher.builder()
                            .pollTimeout(properties.getFetcher().getPollTimeout())
                            .build();

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -149,7 +149,7 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutdown")
     public Fetcher kafkaFetcher() {
-        return AsyncFetcher.<String, byte[]>builder()
+        return AsyncFetcher.builder()
                 .pollTimeout(properties.getFetcher().getPollTimeout())
                 .build();
     }

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2018. Axon Framework
+  ~ Copyright (c) 2010-2019. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -86,6 +86,12 @@
             <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
+
 /**
  * Async implementation of the {@link Fetcher} using an {@link ExecutorService} to schedule {@link FetchEventsTask}s to
  * poll {@link org.apache.kafka.clients.consumer.ConsumerRecords}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
@@ -17,9 +17,7 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.axonframework.common.AxonThreadFactory;
-import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 
 import java.time.Duration;
 import java.util.Set;
@@ -59,14 +57,10 @@ public class AsyncFetcher<E, K, V> implements Fetcher<E, K, V> {
      * The {@code pollTimeout} is defaulted to a {@link Duration} of {@code 5000} milliseconds and the {@link
      * ExecutorService} to an {@link Executors#newCachedThreadPool()} using an {@link AxonThreadFactory}.
      *
-     * @param <K> a generic type for the key of the {@link ConsumerFactory}, {@link ConsumerRecord} and {@link
-     *            KafkaMessageConverter}
-     * @param <V> a generic type for the value of the {@link ConsumerFactory}, {@link ConsumerRecord} and {@link
-     *            KafkaMessageConverter}
      * @return a Builder to be able to create an {@link AsyncFetcher}
      */
-    public static <K, V> Builder<K, V> builder() {
-        return new Builder<>();
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -75,7 +69,7 @@ public class AsyncFetcher<E, K, V> implements Fetcher<E, K, V> {
      * @param builder the {@link Builder} used to instantiate a {@link AsyncFetcher} instance
      */
     @SuppressWarnings("WeakerAccess")
-    protected AsyncFetcher(Builder<K, V> builder) {
+    protected AsyncFetcher(Builder builder) {
         this.pollTimeout = builder.pollTimeout;
         this.executorService = builder.executorService;
         this.requirePoolShutdown = builder.requirePoolShutdown;
@@ -107,13 +101,8 @@ public class AsyncFetcher<E, K, V> implements Fetcher<E, K, V> {
      * <p>
      * The {@code pollTimeout} is defaulted to a {@link Duration} of {@code 5000} milliseconds and the {@link
      * ExecutorService} to an {@link Executors#newCachedThreadPool()} using an {@link AxonThreadFactory}.
-     *
-     * @param <K> a generic type for the key of the {@link ConsumerFactory}, {@link ConsumerRecord} and {@link
-     *            KafkaMessageConverter}
-     * @param <V> a generic type for the value of the {@link ConsumerFactory}, {@link ConsumerRecord} and {@link
-     *            KafkaMessageConverter}
      */
-    public static final class Builder<K, V> {
+    public static final class Builder {
 
         private Duration pollTimeout = Duration.ofMillis(DEFAULT_POLL_TIMEOUT_MS);
         private ExecutorService executorService = Executors.newCachedThreadPool(new AxonThreadFactory("AsyncFetcher"));
@@ -126,7 +115,7 @@ public class AsyncFetcher<E, K, V> implements Fetcher<E, K, V> {
          * @param timeoutMillis the timeoutMillis as a {@code long} when reading message from the topic
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder<K, V> pollTimeout(long timeoutMillis) {
+        public Builder pollTimeout(long timeoutMillis) {
             assertThat(timeoutMillis, timeout -> timeout > 0,
                        "The poll timeout may not be negative [" + timeoutMillis + "]");
             this.pollTimeout = Duration.ofMillis(timeoutMillis);
@@ -147,7 +136,7 @@ public class AsyncFetcher<E, K, V> implements Fetcher<E, K, V> {
          * @return the current Builder instance, for fluent interfacing
          */
         @SuppressWarnings("WeakerAccess")
-        public Builder<K, V> executorService(ExecutorService executorService) {
+        public Builder executorService(ExecutorService executorService) {
             assertNonNull(executorService, "ExecutorService may not be null");
             this.requirePoolShutdown = false;
             this.executorService = executorService;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
@@ -18,55 +18,46 @@ package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.AxonThreadFactory;
-import org.axonframework.common.stream.BlockingStream;
-import org.axonframework.eventhandling.TrackedEventMessage;
-import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
 import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
-import org.axonframework.serialization.xml.XStreamSerializer;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.Supplier;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 
 /**
- * Async implementation of the {@link Fetcher} that uses an in-memory buffer factory.
+ * Async implementation of the {@link Fetcher} using an {@link ExecutorService} to schedule {@link FetchEventsTask}s to
+ * poll {@link org.apache.kafka.clients.consumer.ConsumerRecords}.
  *
- * @param <K> the key of the Kafka {@link org.apache.kafka.clients.consumer.ConsumerRecords}
- * @param <V> the value type of Kafka {@link org.apache.kafka.clients.consumer.ConsumerRecords}
+ * @param <E> the element type the {@link org.apache.kafka.clients.consumer.ConsumerRecords} will be converted in to by
+ *            the {@link RecordConverter} and consumed by the {@link RecordConsumer}
+ * @param <K> the key of the {@link org.apache.kafka.clients.consumer.ConsumerRecords} polled by the {@link
+ *            FetchEventsTask}
+ * @param <V> the value type of {@link org.apache.kafka.clients.consumer.ConsumerRecords} polled by the {@link
+ *            FetchEventsTask}
  * @author Nakul Mishra
  * @author Steven van Beelen
  * @since 4.0
  */
-public class AsyncFetcher<K, V> implements Fetcher {
+public class AsyncFetcher<E, K, V> implements Fetcher<E, K, V> {
 
-    private final ConsumerFactory<K, V> consumerFactory;
-    private final String topic;
-    private final Supplier<Buffer<KafkaEventMessage>> bufferFactory;
+    private static final int DEFAULT_POLL_TIMEOUT_MS = 5_000;
+
     private final Duration pollTimeout;
-    private final KafkaMessageConverter<K, V> messageConverter;
     private final ExecutorService executorService;
     private final boolean requirePoolShutdown;
-
     private final Set<FetchEventsTask> activeFetchers = ConcurrentHashMap.newKeySet();
 
     /**
      * Instantiate a Builder to be able to create a {@link AsyncFetcher}.
      * <p>
-     * The {@code bufferFactory} is defaulted to an {@link SortedKafkaMessageBuffer}, the {@link ExecutorService} to an
-     * {@link Executors#newCachedThreadPool()} using an {@link AxonThreadFactory}, the {@link KafkaMessageConverter} to
-     * a {@link DefaultKafkaMessageConverter}, the {@code topic} to {@code "Axon.Events"} and the {@code pollTimeout} to
-     * a {@link Duration} of {@code 5000} milliseconds. The {@link ConsumerFactory} is a <b>hard requirement</b> and as
-     * such should be provided.
+     * The {@code pollTimeout} is defaulted to a {@link Duration} of {@code 5000} milliseconds and the {@link
+     * ExecutorService} to an {@link Executors#newCachedThreadPool()} using an {@link AxonThreadFactory}.
      *
      * @param <K> a generic type for the key of the {@link ConsumerFactory}, {@link ConsumerRecord} and {@link
      *            KafkaMessageConverter}
@@ -80,40 +71,27 @@ public class AsyncFetcher<K, V> implements Fetcher {
 
     /**
      * Instantiate a {@link AsyncFetcher} based on the fields contained in the {@link Builder}.
-     * <p>
-     * Will assert that the {@link ConsumerFactory} is not {@code null}, and will throw an {@link
-     * AxonConfigurationException} if it is {@code null}.
      *
      * @param builder the {@link Builder} used to instantiate a {@link AsyncFetcher} instance
      */
     @SuppressWarnings("WeakerAccess")
     protected AsyncFetcher(Builder<K, V> builder) {
-        builder.validate();
-        this.consumerFactory = builder.consumerFactory;
-        this.topic = builder.topic;
-        this.bufferFactory = builder.bufferFactory;
         this.pollTimeout = builder.pollTimeout;
-        this.messageConverter = builder.messageConverter;
         this.executorService = builder.executorService;
         this.requirePoolShutdown = builder.requirePoolShutdown;
     }
 
     @Override
-    public BlockingStream<TrackedEventMessage<?>> start(KafkaTrackingToken token, String groupId) {
-        Consumer<K, V> consumer = consumerFactory.createConsumer(groupId);
-        ConsumerUtil.seek(topic, consumer, token);
+    public Runnable poll(Consumer<K, V> consumer,
+                         RecordConverter<E, K, V> recordConverter,
+                         RecordConsumer<E> recordConsumer) {
+        FetchEventsTask<E, K, V> fetcherTask =
+                new FetchEventsTask<>(consumer, pollTimeout, recordConverter, recordConsumer, activeFetchers::remove);
 
-        if (KafkaTrackingToken.isEmpty(token)) {
-            token = KafkaTrackingToken.emptyToken();
-        }
-
-        Buffer<KafkaEventMessage> buffer = bufferFactory.get();
-        FetchEventsTask<K, V> fetcherTask =
-                new FetchEventsTask<>(consumer, pollTimeout, messageConverter, buffer, activeFetchers::remove, token);
         activeFetchers.add(fetcherTask);
         executorService.execute(fetcherTask);
 
-        return new KafkaMessageStream(buffer, fetcherTask::close);
+        return fetcherTask::close;
     }
 
     @Override
@@ -127,11 +105,8 @@ public class AsyncFetcher<K, V> implements Fetcher {
     /**
      * Builder class to instantiate an {@link AsyncFetcher}.
      * <p>
-     * The {@code bufferFactory} is defaulted to an {@link SortedKafkaMessageBuffer}, the {@link ExecutorService} to an
-     * {@link Executors#newCachedThreadPool()} using an {@link AxonThreadFactory}, the {@link KafkaMessageConverter} to
-     * a {@link DefaultKafkaMessageConverter}, the {@code topic} to {@code "Axon.Events"} and the {@code pollTimeout} to
-     * a {@link Duration} of {@code 5000} milliseconds. The {@link ConsumerFactory} is a <b>hard requirement</b> and as
-     * such should be provided.
+     * The {@code pollTimeout} is defaulted to a {@link Duration} of {@code 5000} milliseconds and the {@link
+     * ExecutorService} to an {@link Executors#newCachedThreadPool()} using an {@link AxonThreadFactory}.
      *
      * @param <K> a generic type for the key of the {@link ConsumerFactory}, {@link ConsumerRecord} and {@link
      *            KafkaMessageConverter}
@@ -140,119 +115,35 @@ public class AsyncFetcher<K, V> implements Fetcher {
      */
     public static final class Builder<K, V> {
 
-        private ConsumerFactory<K, V> consumerFactory;
-        private String topic = "Axon.Events";
-        private Supplier<Buffer<KafkaEventMessage>> bufferFactory = SortedKafkaMessageBuffer::new;
-        private Duration pollTimeout = Duration.ofMillis(5_000);
-        @SuppressWarnings("unchecked")
-        private KafkaMessageConverter<K, V> messageConverter =
-                (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder().serializer(
-                        XStreamSerializer.builder().build()
-                ).build();
-        private ExecutorService executorService =
-                Executors.newCachedThreadPool(new AxonThreadFactory("AsyncFetcher-pool-thread"));
+        private Duration pollTimeout = Duration.ofMillis(DEFAULT_POLL_TIMEOUT_MS);
+        private ExecutorService executorService = Executors.newCachedThreadPool(new AxonThreadFactory("AsyncFetcher"));
         private boolean requirePoolShutdown = true;
 
         /**
-         * Sets the {@link ConsumerFactory} to be used by this {@link Fetcher} implementation to create {@link Consumer}
-         * instances.
-         *
-         * @param consumerFactory a {@link ConsumerFactory} to be used by this {@link Fetcher} implementation to create
-         *                        {@link Consumer} instances
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder<K, V> consumerFactory(ConsumerFactory<K, V> consumerFactory) {
-            assertNonNull(consumerFactory, "ConsumerFactory may not be null");
-            this.consumerFactory = consumerFactory;
-            return this;
-        }
-
-        /**
-         * Instantiate a {@link DefaultConsumerFactory} with the provided {@code consumerConfiguration}. Used by this
-         * {@link Fetcher} implementation to create {@link Consumer} instances.
-         *
-         * @param consumerConfiguration a {@link DefaultConsumerFactory} with the given {@code consumerConfiguration},
-         *                              to be used by this {@link Fetcher} implementation to create {@link Consumer}
-         *                              instances
-         * @return the current Builder instance, for fluent interfacing
-         */
-        @SuppressWarnings("WeakerAccess")
-        public Builder<K, V> consumerFactory(Map<String, Object> consumerConfiguration) {
-            this.consumerFactory = new DefaultConsumerFactory<>(consumerConfiguration);
-            return this;
-        }
-
-        /**
-         * Set the Kafka {@code topic} to read {@link org.axonframework.eventhandling.EventMessage}s from. Defaults to
-         * {@code Axon.Events}.
-         *
-         * @param topic the Kafka {@code topic} to read {@link org.axonframework.eventhandling.EventMessage}s from
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder<K, V> topic(String topic) {
-            assertThat(topic, name -> Objects.nonNull(name) && !"".equals(name), "The topic may not be null or empty");
-            this.topic = topic;
-            return this;
-        }
-
-        /**
-         * Sets the {@code bufferFactory} of type {@link Supplier} with a generic type {@link Buffer} with {@link
-         * KafkaEventMessage}s. Used to create a buffer for the Kafka records fetcher. Defaults to a {@link
-         * SortedKafkaMessageBuffer}.
-         *
-         * @param bufferFactory a {@link Supplier} to create a buffer for the Kafka records fetcher
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder<K, V> bufferFactory(Supplier<Buffer<KafkaEventMessage>> bufferFactory) {
-            assertNonNull(bufferFactory, "Buffer factory may not be null");
-            this.bufferFactory = bufferFactory;
-            return this;
-        }
-
-        /**
-         * Set the {@code pollTimeout} in milliseconds for reading messages from a topic. Defaults to {@code 5000}
+         * Set the {@code pollTimeout} in milliseconds for polling records from a topic. Defaults to {@code 5000}
          * milliseconds.
          *
          * @param timeoutMillis the timeoutMillis as a {@code long} when reading message from the topic
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> pollTimeout(long timeoutMillis) {
-            assertThat(
-                    timeoutMillis, timeout -> timeout > 0,
-                    "The poll timeout may not be negative [" + timeoutMillis + "]"
-            );
+            assertThat(timeoutMillis, timeout -> timeout > 0,
+                       "The poll timeout may not be negative [" + timeoutMillis + "]");
             this.pollTimeout = Duration.ofMillis(timeoutMillis);
             return this;
         }
 
         /**
-         * Sets the {@link KafkaMessageConverter} used to convert Kafka messages into {@link
-         * org.axonframework.eventhandling.EventMessage}s. Defaults to a {@link DefaultKafkaMessageConverter} using the
-         * {@link XStreamSerializer}.
-         * <p>
-         * Note that configuring a MessageConverter on the builder is mandatory if the value type is not {@code
-         * byte[]}.
-         *
-         * @param messageConverter a {@link KafkaMessageConverter} used to convert Kafka messages into {@link
-         *                         org.axonframework.eventhandling.EventMessage}s
-         * @return the current Builder instance, for fluent interfacing
-         */
-        public Builder<K, V> messageConverter(KafkaMessageConverter<K, V> messageConverter) {
-            assertNonNull(messageConverter, "MessageConverter may not be null");
-            this.messageConverter = messageConverter;
-            return this;
-        }
-
-        /**
-         * Sets the {@link ExecutorService} used to start {@link Consumer} instances for fetching Kafka records. Note
-         * that the {@code executorService} should contain sufficient threads to run the necessary fetcher processes
-         * concurrently. Defaults to an {@link Executors#newCachedThreadPool()} with an {@link AxonThreadFactory}.
+         * Sets the {@link ExecutorService} used to start {@link FetchEventsTask} instances to poll for Kafka consumer
+         * records. Note that the {@code executorService} should contain sufficient threads to run the necessary fetcher
+         * processes concurrently. Defaults to an {@link Executors#newCachedThreadPool()} with an {@link
+         * AxonThreadFactory}.
          * <p>
          * Note that the provided {@code executorService} will <em>not</em> be shut down when the fetcher is
          * terminated.
          *
-         * @param executorService a {@link ExecutorService} used to start {@link Consumer} instances for fetching Kafka
-         *                        records
+         * @param executorService a {@link ExecutorService} used to start {@link FetchEventsTask} instances to poll for
+         *                        Kafka consumer records
          * @return the current Builder instance, for fluent interfacing
          */
         @SuppressWarnings("WeakerAccess")
@@ -270,17 +161,6 @@ public class AsyncFetcher<K, V> implements Fetcher {
          */
         public AsyncFetcher build() {
             return new AsyncFetcher<>(this);
-        }
-
-        /**
-         * Validates whether the fields contained in this Builder are set accordingly.
-         *
-         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
-         *                                    specifications
-         */
-        @SuppressWarnings("WeakerAccess")
-        protected void validate() throws AxonConfigurationException {
-            assertNonNull(consumerFactory, "The ConsumerFactory is a hard requirement and should be provided");
         }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
-
 /**
  * Async implementation of the {@link Fetcher} using an {@link ExecutorService} to schedule {@link FetchEventsTask}s to
  * poll {@link org.apache.kafka.clients.consumer.ConsumerRecords}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/EventConsumer.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/EventConsumer.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @since 4.0
  */
 @FunctionalInterface
-public interface RecordConsumer<E> {
+public interface EventConsumer<E> {
 
     /**
      * Consume a {@link List} of records of type {@code E}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -25,19 +25,19 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
 
 import static org.axonframework.common.Assert.nonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
- * Polls a {@link Consumer} for new records and inserts these, after conversion by the {@link KafkaMessageConverter},
- * in a {@link Buffer}. It is also in charge of updating the {@link KafkaTrackingToken} it's partitions and their
+ * Polls a {@link Consumer} for new records and inserts these, after conversion by the {@link KafkaMessageConverter}, in
+ * a {@link Buffer}. It is also in charge of updating the {@link KafkaTrackingToken} it's partitions and their
  * respective offsets.
  *
+ * @param <K> the key of the Kafka {@link ConsumerRecords}
+ * @param <V> the value type of Kafka {@link ConsumerRecords}
  * @author Nakul Mishra
  * @author Steven van Beelen
  * @since 4.0
@@ -50,34 +50,29 @@ class FetchEventsTask<K, V> implements Runnable {
     private final Duration pollTimeout;
     private final KafkaMessageConverter<K, V> converter;
     private final Buffer<KafkaEventMessage> buffer;
-    private final BiFunction<ConsumerRecord<K, V>, KafkaTrackingToken, Void> consumerRecordCallback;
     private final java.util.function.Consumer<FetchEventsTask> closeHandler;
 
     private KafkaTrackingToken currentToken;
     private final AtomicBoolean running = new AtomicBoolean(true);
 
     /**
-     * Create a fetch events {@link Runnable} task. The {@link Consumer} is used to periodically
-     * {@link Consumer#poll(Duration)} for new {@link ConsumerRecords}. These are in turn converted (with the given
-     * {@code converter}) and appended to the {@code buffer}. Every new {@link ConsumerRecord} will advance the given
-     * {@code token}'s position.
+     * Create a fetch events {@link Runnable} task. The {@link Consumer} is used to periodically {@link
+     * Consumer#poll(Duration)} for new {@link ConsumerRecords}. These are in turn converted (with the given {@code
+     * converter}) and appended to the {@code buffer}. Every new {@link ConsumerRecord} will advance the given {@code
+     * token}'s position.
      *
-     * @param consumer               the {@link Consumer} used to {@link Consumer#poll(Duration)} {@link
-     *                               ConsumerRecords} from
-     * @param pollTimeout            the {@link Duration} used for the {@link Consumer#poll(Duration)} call
-     * @param converter              the {@link KafkaMessageConverter} used to convert a {@link ConsumerRecord} in to a
-     *                               {@link KafkaEventMessage}
-     * @param buffer                 the {@link Buffer} used to store fetched {@link KafkaEventMessage}s in
-     * @param consumerRecordCallback a callback mechanism invoked on every fetched {@link ConsumerRecord}. Defaults to a
-     *                               no-op
-     * @param closeHandler           the handler called after this {@link Runnable} is shutdown
-     * @param token                  the {@link KafkaTrackingToken} to advance for every fetched {@link ConsumerRecord}
+     * @param consumer     the {@link Consumer} used to {@link Consumer#poll(Duration)} {@link ConsumerRecords} from
+     * @param pollTimeout  the {@link Duration} used for the {@link Consumer#poll(Duration)} call
+     * @param converter    the {@link KafkaMessageConverter} used to convert a {@link ConsumerRecord} in to a {@link
+     *                     KafkaEventMessage}
+     * @param buffer       the {@link Buffer} used to store fetched {@link KafkaEventMessage}s in
+     * @param closeHandler the handler called after this {@link Runnable} is shutdown
+     * @param token        the {@link KafkaTrackingToken} to advance for every fetched {@link ConsumerRecord}
      */
     FetchEventsTask(Consumer<K, V> consumer,
                     Duration pollTimeout,
                     KafkaMessageConverter<K, V> converter,
                     Buffer<KafkaEventMessage> buffer,
-                    BiFunction<ConsumerRecord<K, V>, KafkaTrackingToken, Void> consumerRecordCallback,
                     java.util.function.Consumer<FetchEventsTask> closeHandler,
                     KafkaTrackingToken token) {
         this.consumer = nonNull(consumer, () -> "Consumer may not be null");
@@ -88,8 +83,6 @@ class FetchEventsTask<K, V> implements Runnable {
         this.pollTimeout = pollTimeout;
         this.converter = nonNull(converter, () -> "Converter may not be null");
         this.buffer = nonNull(buffer, () -> "Buffer may not be null");
-        this.consumerRecordCallback =
-                nonNull(consumerRecordCallback, () -> "The ConsumerRecord callback may not be null");
         this.closeHandler = getOrDefault(closeHandler, task -> { /* no-op */ });
         this.currentToken = nonNull(token, () -> "Token may not be null");
     }
@@ -100,33 +93,24 @@ class FetchEventsTask<K, V> implements Runnable {
             while (running.get()) {
                 ConsumerRecords<K, V> records = consumer.poll(pollTimeout);
                 Collection<KafkaEventMessage> eventMessages = new ArrayList<>(records.count());
-                List<ConsumerRecordCallbackEntry<K, V>> callbacks = new ArrayList<>(records.count());
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Fetched [{}] number of records", records.count());
-                }
+                logger.debug("Fetched [{}] number of records", records.count());
+
                 // Convert every ConsumerRecord into a KafkaEventMessage and advance the TrackingToken
                 for (ConsumerRecord<K, V> record : records) {
                     converter.readKafkaMessage(record).ifPresent(eventMessage -> {
                         KafkaTrackingToken nextToken = currentToken.advancedTo(record.partition(), record.offset());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Advancing token from [{}] to [{}]", currentToken, nextToken);
-                        }
+                        logger.debug("Advancing token from [{}] to [{}]", currentToken, nextToken);
                         currentToken = nextToken;
 
                         eventMessages.add(KafkaEventMessage.from(eventMessage, record, currentToken));
-                        callbacks.add(new ConsumerRecordCallbackEntry<>(record, currentToken));
                     });
                 }
-                // Add all the event messages in the buffer and call every consumer callback
+
+                // Add all the event messages in the buffer
                 try {
                     buffer.putAll(eventMessages);
-                    for (ConsumerRecordCallbackEntry<K, V> c : callbacks) {
-                        this.consumerRecordCallback.apply(c.getRecord(), c.getToken());
-                    }
                 } catch (InterruptedException e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Event Consumer thread was interrupted. Shutting down", e);
-                    }
+                    logger.debug("Event Consumer thread was interrupted. Shutting down", e);
                     running.set(false);
                     Thread.currentThread().interrupt();
                 }
@@ -145,41 +129,5 @@ class FetchEventsTask<K, V> implements Runnable {
      */
     public void close() {
         this.running.set(false);
-    }
-
-    /**
-     * Container for a {@link KafkaTrackingToken} and {@link ConsumerRecord} to be used by the ConsumerRecord callback
-     * mechanism.
-     *
-     * @param <K> the key type of the  {@link ConsumerRecord}
-     * @param <V> the value type of the  {@link ConsumerRecord}
-     */
-    private static class ConsumerRecordCallbackEntry<K, V> {
-
-        private final ConsumerRecord<K, V> record;
-        private final KafkaTrackingToken token;
-
-        private ConsumerRecordCallbackEntry(ConsumerRecord<K, V> record, KafkaTrackingToken token) {
-            this.token = token;
-            this.record = record;
-        }
-
-        /**
-         * Retrieve the {@link ConsumerRecord} contained in this ConsumerRecord callback entry.
-         *
-         * @return the {@link ConsumerRecord} contained in this ConsumerRecord callback entry
-         */
-        private ConsumerRecord<K, V> getRecord() {
-            return record;
-        }
-
-        /**
-         * Retrieve the {@link KafkaTrackingToken} contained in this ConsumerRecord callback entry.
-         *
-         * @return the {@link KafkaTrackingToken} contained in this ConsumerRecord callback entry
-         */
-        private KafkaTrackingToken getToken() {
-            return token;
-        }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.axonframework.common.Assert.nonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
+
 /**
  * Polls {@link ConsumerRecords} with a {@link Consumer}. These ConsumerRecords will be converted by a {@link
  * RecordConverter} and afterwards consumed by a {@link RecordConsumer}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -49,7 +49,7 @@ class FetchEventsTask<E, K, V> implements Runnable {
     private final Duration pollTimeout;
     private final RecordConverter<E, K, V> recordConverter;
     private final RecordConsumer<E> recordConsumer;
-    private final java.util.function.Consumer<FetchEventsTask> closeHandler;
+    private final java.util.function.Consumer<FetchEventsTask<E, K, V>> closeHandler;
 
     private final AtomicBoolean running = new AtomicBoolean(true);
 
@@ -68,7 +68,7 @@ class FetchEventsTask<E, K, V> implements Runnable {
                     Duration pollTimeout,
                     RecordConverter<E, K, V> recordConverter,
                     RecordConsumer<E> recordConsumer,
-                    java.util.function.Consumer<FetchEventsTask> closeHandler) {
+                    java.util.function.Consumer<FetchEventsTask<E, K, V>> closeHandler) {
         this.consumer = nonNull(consumer, () -> "Consumer may not be null");
         assertThat(pollTimeout, time -> !time.isNegative(),
                    "The poll timeout may not be negative [" + pollTimeout + "]");

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -16,15 +16,12 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.axonframework.common.Assert.nonNull;
@@ -32,59 +29,52 @@ import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
 
 /**
- * Polls a {@link Consumer} for new records and inserts these, after conversion by the {@link KafkaMessageConverter}, in
- * a {@link Buffer}. It is also in charge of updating the {@link KafkaTrackingToken} it's partitions and their
- * respective offsets.
+ * Polls {@link ConsumerRecords} with a {@link Consumer}. These ConsumerRecords will be converted by a {@link
+ * RecordConverter} and afterwards consumed by a {@link RecordConsumer}.
  *
- * @param <K> the key of the Kafka {@link ConsumerRecords}
- * @param <V> the value type of Kafka {@link ConsumerRecords}
+ * @param <E> the element type each {@link org.apache.kafka.clients.consumer.ConsumerRecord} instance is converted in
+ *            to
+ * @param <K> the key of the Kafka {@link ConsumerRecords} to be polled, converted and consumed
+ * @param <V> the value type of Kafka {@link ConsumerRecords} to be polled, converted and consumed
  * @author Nakul Mishra
  * @author Steven van Beelen
  * @since 4.0
  */
-class FetchEventsTask<K, V> implements Runnable {
+class FetchEventsTask<E, K, V> implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(FetchEventsTask.class);
 
     private final Consumer<K, V> consumer;
     private final Duration pollTimeout;
-    private final KafkaMessageConverter<K, V> converter;
-    private final Buffer<KafkaEventMessage> buffer;
+    private final RecordConverter<E, K, V> recordConverter;
+    private final RecordConsumer<E> recordConsumer;
     private final java.util.function.Consumer<FetchEventsTask> closeHandler;
 
-    private KafkaTrackingToken currentToken;
     private final AtomicBoolean running = new AtomicBoolean(true);
 
     /**
      * Create a fetch events {@link Runnable} task. The {@link Consumer} is used to periodically {@link
-     * Consumer#poll(Duration)} for new {@link ConsumerRecords}. These are in turn converted (with the given {@code
-     * converter}) and appended to the {@code buffer}. Every new {@link ConsumerRecord} will advance the given {@code
-     * token}'s position.
+     * Consumer#poll(Duration)} for new {@link ConsumerRecords}. These are in turn converted with the given {@code
+     * recordConverter} and consumed by the {@code recordConsumer}.
      *
-     * @param consumer     the {@link Consumer} used to {@link Consumer#poll(Duration)} {@link ConsumerRecords} from
-     * @param pollTimeout  the {@link Duration} used for the {@link Consumer#poll(Duration)} call
-     * @param converter    the {@link KafkaMessageConverter} used to convert a {@link ConsumerRecord} in to a {@link
-     *                     KafkaEventMessage}
-     * @param buffer       the {@link Buffer} used to store fetched {@link KafkaEventMessage}s in
-     * @param closeHandler the handler called after this {@link Runnable} is shutdown
-     * @param token        the {@link KafkaTrackingToken} to advance for every fetched {@link ConsumerRecord}
+     * @param consumer        the {@link Consumer} used to {@link Consumer#poll(Duration)} {@link ConsumerRecords} from
+     * @param pollTimeout     the {@link Duration} used for the {@link Consumer#poll(Duration)} call
+     * @param recordConverter the {@link RecordConverter} used to convert the retrieved {@link ConsumerRecords}
+     * @param recordConsumer  the {@link RecordConsumer} used to consume the converted {@link ConsumerRecords}
+     * @param closeHandler    the handler called after this {@link Runnable} is shutdown
      */
     FetchEventsTask(Consumer<K, V> consumer,
                     Duration pollTimeout,
-                    KafkaMessageConverter<K, V> converter,
-                    Buffer<KafkaEventMessage> buffer,
-                    java.util.function.Consumer<FetchEventsTask> closeHandler,
-                    KafkaTrackingToken token) {
+                    RecordConverter<E, K, V> recordConverter,
+                    RecordConsumer<E> recordConsumer,
+                    java.util.function.Consumer<FetchEventsTask> closeHandler) {
         this.consumer = nonNull(consumer, () -> "Consumer may not be null");
-        assertThat(
-                pollTimeout, time -> !time.isNegative(),
-                "The poll timeout may not be negative [" + pollTimeout + "]"
-        );
+        assertThat(pollTimeout, time -> !time.isNegative(),
+                   "The poll timeout may not be negative [" + pollTimeout + "]");
         this.pollTimeout = pollTimeout;
-        this.converter = nonNull(converter, () -> "Converter may not be null");
-        this.buffer = nonNull(buffer, () -> "Buffer may not be null");
+        this.recordConverter = recordConverter;
+        this.recordConsumer = recordConsumer;
         this.closeHandler = getOrDefault(closeHandler, task -> { /* no-op */ });
-        this.currentToken = nonNull(token, () -> "Token may not be null");
     }
 
     @Override
@@ -92,23 +82,10 @@ class FetchEventsTask<K, V> implements Runnable {
         try {
             while (running.get()) {
                 ConsumerRecords<K, V> records = consumer.poll(pollTimeout);
-                Collection<KafkaEventMessage> eventMessages = new ArrayList<>(records.count());
-                logger.debug("Fetched [{}] number of records", records.count());
-
-                // Convert every ConsumerRecord into a KafkaEventMessage and advance the TrackingToken
-                for (ConsumerRecord<K, V> record : records) {
-                    converter.readKafkaMessage(record).ifPresent(eventMessage -> {
-                        KafkaTrackingToken nextToken = currentToken.advancedTo(record.partition(), record.offset());
-                        logger.debug("Advancing token from [{}] to [{}]", currentToken, nextToken);
-                        currentToken = nextToken;
-
-                        eventMessages.add(KafkaEventMessage.from(eventMessage, record, currentToken));
-                    });
-                }
-
-                // Add all the event messages in the buffer
+                logger.debug("Fetched [{}] number of ConsumerRecords", records.count());
+                List<E> convertedMessages = recordConverter.convert(records);
                 try {
-                    buffer.putAll(eventMessages);
+                    recordConsumer.consume(convertedMessages);
                 } catch (InterruptedException e) {
                     logger.debug("Event Consumer thread was interrupted. Shutting down", e);
                     running.set(false);
@@ -125,7 +102,7 @@ class FetchEventsTask<K, V> implements Runnable {
     }
 
     /**
-     * Shutdown this task.
+     * Shutdown this {@link FetchEventsTask}.
      */
     public void close() {
         this.running.set(false);

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.axonframework.common.Assert.nonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
 import static org.axonframework.common.ObjectUtils.getOrDefault;
-
 /**
  * Polls {@link ConsumerRecords} with a {@link Consumer}. These ConsumerRecords will be converted by a {@link
  * RecordConverter} and afterwards consumed by a {@link RecordConsumer}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
@@ -17,35 +17,39 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.axonframework.common.Registration;
 
 /**
  * Interface describing the component responsible for fetching messages from a Kafka topic through a {@link Consumer}.
  *
- * @param <E> the element type the {@link org.apache.kafka.clients.consumer.ConsumerRecords} will be converted in to by
- *            the {@link RecordConverter} and consumed by the {@link RecordConsumer}
  * @param <K> the key of the {@link org.apache.kafka.clients.consumer.ConsumerRecords} produced in the {@link Consumer}
  *            and used in the {@link RecordConverter}
  * @param <V> the value type of {@link org.apache.kafka.clients.consumer.ConsumerRecords} produced in the {@link
  *            Consumer} and used in the {@link RecordConverter}
+ * @param <E> the element type the {@link org.apache.kafka.clients.consumer.ConsumerRecords} will be converted in to by
+ *            the {@link RecordConverter} and consumed by the {@link EventConsumer}
  * @author Nakul Mishra
  * @author Steven van Beelen
  * @since 4.0
  */
-public interface Fetcher<E, K, V> {
+public interface Fetcher<K, V, E> {
 
     /**
      * Instruct this Fetcher to start polling message through the provided {@link Consumer}. After retrieval, the {@link
      * org.apache.kafka.clients.consumer.ConsumerRecords} will be converted by the given {@code recordConverter} and
-     * thereafter consumed by the given {@code recordConsumer}. A close handler will be returned to stop message
-     * consumption and conversion.
+     * there after consumed by the given {@code recordConsumer}. A {@link Registration} will be returned to cancel
+     * message consumption and conversion.
      *
      * @param consumer        the {@link Consumer} used to consume message from a Kafka topic
      * @param recordConverter a {@link RecordConverter} instance which will convert the "consumed" {@link
      *                        org.apache.kafka.clients.consumer.ConsumerRecords} in to a  List of {@code E}
-     * @param recordConsumer  a {@link RecordConsumer} instance which will consume the converted records
-     * @return a close handler of type {@link Runnable} to stop the {@link Fetcher}
+     * @param eventConsumer   a {@link EventConsumer} instance which will consume the converted records
+     * @return a close handler of type {@link org.axonframework.common.Registration} to stop the {@link Fetcher}
+     * operation
      */
-    Runnable poll(Consumer<K, V> consumer, RecordConverter<E, K, V> recordConverter, RecordConsumer<E> recordConsumer);
+    Registration poll(Consumer<K, V> consumer,
+                      RecordConverter<K, V, E> recordConverter,
+                      EventConsumer<E> eventConsumer);
 
     /**
      * Shuts the fetcher down, closing any resources used by this fetcher.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
@@ -16,25 +16,36 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
-import org.axonframework.common.stream.BlockingStream;
-import org.axonframework.eventhandling.TrackedEventMessage;
+import org.apache.kafka.clients.consumer.Consumer;
 
 /**
- * Interface describing the component responsible for reading messages from a Kafka topic through a Consumer.
+ * Interface describing the component responsible for fetching messages from a Kafka topic through a {@link Consumer}.
  *
+ * @param <E> the element type the {@link org.apache.kafka.clients.consumer.ConsumerRecords} will be converted in to by
+ *            the {@link RecordConverter} and consumed by the {@link RecordConsumer}
+ * @param <K> the key of the {@link org.apache.kafka.clients.consumer.ConsumerRecords} produced in the {@link Consumer}
+ *            and used in the {@link RecordConverter}
+ * @param <V> the value type of {@link org.apache.kafka.clients.consumer.ConsumerRecords} produced in the {@link
+ *            Consumer} and used in the {@link RecordConverter}
  * @author Nakul Mishra
+ * @author Steven van Beelen
  * @since 4.0
  */
-public interface Fetcher {
+public interface Fetcher<E, K, V> {
 
     /**
-     * Open a stream of messages, starting at the position indicated by the given {@code token}.
+     * Instruct this Fetcher to start polling message through the provided {@link Consumer}. After retrieval, the {@link
+     * org.apache.kafka.clients.consumer.ConsumerRecords} will be converted by the given {@code recordConverter} and
+     * thereafter consumed by the given {@code recordConsumer}. A close handler will be returned to stop message
+     * consumption and conversion.
      *
-     * @param token   the token representing positions of the partitions to start from
-     * @param groupId a {@link String} defining the Consumer Group id the fetcher should start Consumer instances in
-     * @return a {@link BlockingStream} providing messages from Kafka
+     * @param consumer        the {@link Consumer} used to consume message from a Kafka topic
+     * @param recordConverter a {@link RecordConverter} instance which will convert the "consumed" {@link
+     *                        org.apache.kafka.clients.consumer.ConsumerRecords} in to a  List of {@code E}
+     * @param recordConsumer  a {@link RecordConsumer} instance which will consume the converted records
+     * @return a close handler of type {@link Runnable} to stop the {@link Fetcher}
      */
-    BlockingStream<TrackedEventMessage<?>> start(KafkaTrackingToken token, String groupId);
+    Runnable poll(Consumer<K, V> consumer, RecordConverter<E, K, V> recordConverter, RecordConsumer<E> recordConsumer);
 
     /**
      * Shuts the fetcher down, closing any resources used by this fetcher.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,6 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
-
 /**
  * Interface describing the component responsible for fetching messages from a Kafka topic through a {@link Consumer}.
  *

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
@@ -17,6 +17,7 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.Consumer;
+
 /**
  * Interface describing the component responsible for fetching messages from a Kafka topic through a {@link Consumer}.
  *

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStream.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
+import org.axonframework.common.Registration;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingEventStream;
 import org.slf4j.Logger;
@@ -27,9 +28,9 @@ import java.util.concurrent.TimeUnit;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
- * Create message stream from a specific kafka topic. Messages are fetch in bulk and stored in an in-memory buffer. We
- * try to introduce some sort and stored them in a local buffer. Consumer position is tracked via
- * {@link KafkaTrackingToken}. Records are fetched from kafka and stored in-memory buffer.
+ * Create message stream from a specific Kafka topic. Messages are fetch in bulk and stored in an in-memory buffer. We
+ * try to introduce some sort and stored them in a local buffer. Consumer position is tracked via {@link
+ * KafkaTrackingToken}. Records are fetched from Kafka and stored in-memory buffer.
  * <p>
  * This is not thread safe.
  *
@@ -42,7 +43,7 @@ public class KafkaMessageStream implements TrackingEventStream {
     private static final Logger logger = LoggerFactory.getLogger(KafkaMessageStream.class);
 
     private final Buffer<KafkaEventMessage> buffer;
-    private final Runnable closeHandler;
+    private final Registration closeHandler;
     private KafkaEventMessage peekedEvent;
 
     /**
@@ -50,10 +51,11 @@ public class KafkaMessageStream implements TrackingEventStream {
      * retrieve event messages from.
      *
      * @param buffer       the {@link KafkaEventMessage} {@link Buffer} containing the fetched messages
-     * @param closeHandler the {@link Runnable} called upon executing a {@link #close()}
+     * @param closeHandler the service {@link Registration} which fills the buffer. Will be canceled upon executing a
+     *                     {@link #close()}
      */
     @SuppressWarnings("WeakerAccess")
-    public KafkaMessageStream(Buffer<KafkaEventMessage> buffer, Runnable closeHandler) {
+    public KafkaMessageStream(Buffer<KafkaEventMessage> buffer, Registration closeHandler) {
         assertNonNull(buffer, "Buffer may not be null");
         this.buffer = buffer;
         this.closeHandler = closeHandler;
@@ -93,7 +95,7 @@ public class KafkaMessageStream implements TrackingEventStream {
     @Override
     public void close() {
         if (closeHandler != null) {
-            closeHandler.run();
+            closeHandler.cancel();
         }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConsumer.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConsumer.java
@@ -1,7 +1,22 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import java.util.List;
-
 /**
  * A functional interface towards consuming a {@link List} of records of type {@code E}. Provides added functionality
  * over the regular {@link java.util.function.Consumer} functional interface by specifying that it might throw an {@link

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConsumer.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConsumer.java
@@ -17,6 +17,7 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import java.util.List;
+
 /**
  * A functional interface towards consuming a {@link List} of records of type {@code E}. Provides added functionality
  * over the regular {@link java.util.function.Consumer} functional interface by specifying that it might throw an {@link

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConsumer.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConsumer.java
@@ -1,0 +1,24 @@
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import java.util.List;
+
+/**
+ * A functional interface towards consuming a {@link List} of records of type {@code E}. Provides added functionality
+ * over the regular {@link java.util.function.Consumer} functional interface by specifying that it might throw an {@link
+ * InterruptedException}.
+ *
+ * @param <E> the element type of the records to consume
+ * @author Steven van Beelen
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface RecordConsumer<E> {
+
+    /**
+     * Consume a {@link List} of records of type {@code E}.
+     *
+     * @param records the {@link List} of type {@code E} to consume
+     * @throws InterruptedException if consumption is interrupted
+     */
+    void consume(List<E> records) throws InterruptedException;
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
@@ -19,11 +19,13 @@ package org.axonframework.extensions.kafka.eventhandling.consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 import java.util.List;
+
 /**
  * A functional interface towards converting the {@link org.apache.kafka.clients.consumer.ConsumerRecord} instances in
  * to a {@link List} of {@code E}.
  *
- * @param <E> the element type each {@link org.apache.kafka.clients.consumer.ConsumerRecord} instance is converted in to
+ * @param <E> the element type each {@link org.apache.kafka.clients.consumer.ConsumerRecord} instance is converted in
+ *            to
  * @param <K> the key of the {@link ConsumerRecords}
  * @param <V> the value type of {@link ConsumerRecords}
  * @author Steven van Beelen

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
@@ -24,15 +24,14 @@ import java.util.List;
  * A functional interface towards converting the {@link org.apache.kafka.clients.consumer.ConsumerRecord} instances in
  * to a {@link List} of {@code E}.
  *
- * @param <E> the element type each {@link org.apache.kafka.clients.consumer.ConsumerRecord} instance is converted in
- *            to
  * @param <K> the key of the {@link ConsumerRecords}
  * @param <V> the value type of {@link ConsumerRecords}
+ * @param <E> the element type each {@link org.apache.kafka.clients.consumer.ConsumerRecord} instance is converted to
  * @author Steven van Beelen
  * @since 4.0
  */
 @FunctionalInterface
-public interface RecordConverter<E, K, V> {
+public interface RecordConverter<K, V, E> {
 
     /**
      * Covert the provided {@code records} in to a {@link List} of elements of type {@code E}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
@@ -1,0 +1,27 @@
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import java.util.List;
+
+/**
+ * A functional interface towards converting the {@link org.apache.kafka.clients.consumer.ConsumerRecord} instances in
+ * to a {@link List} of {@code E}.
+ *
+ * @param <E> the element type each {@link org.apache.kafka.clients.consumer.ConsumerRecord} instance is converted in to
+ * @param <K> the key of the {@link ConsumerRecords}
+ * @param <V> the value type of {@link ConsumerRecords}
+ * @author Steven van Beelen
+ * @since 4.0
+ */
+@FunctionalInterface
+public interface RecordConverter<E, K, V> {
+
+    /**
+     * Covert the provided {@code records} in to a {@link List} of elements of type {@code E}.
+     *
+     * @param records a {@link ConsumerRecords} instance to convert in to a {@link List} of {@code E}
+     * @return the {@link List} of elements of type {@code E}
+     */
+    List<E> convert(ConsumerRecords<K, V> records);
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RecordConverter.java
@@ -1,9 +1,24 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 import java.util.List;
-
 /**
  * A functional interface towards converting the {@link org.apache.kafka.clients.consumer.ConsumerRecord} instances in
  * to a {@link List} of {@code E}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 import static org.axonframework.common.Assert.isTrue;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
+
 /**
  * Implementation of the {@link StreamableMessageSource} that reads messages from a Kafka topic using the provided
  * {@link Fetcher}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import java.util.function.Supplier;
 import static org.axonframework.common.Assert.isTrue;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
-
 /**
  * Implementation of the {@link StreamableMessageSource} that reads messages from a Kafka topic using the provided
  * {@link Fetcher}.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -159,7 +159,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
          *                records from
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder groupId(String groupId) {
+        public Builder<K, V> groupId(String groupId) {
             assertThat(groupId, name -> Objects.nonNull(name) && !"".equals(name),
                        "The groupId may not be null or empty");
             this.groupId = groupId;
@@ -189,6 +189,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
          *                              Consumer} instances with
          * @return the current Builder instance, for fluent interfacing
          */
+        @SuppressWarnings("unused")
         public Builder<K, V> consumerFactory(Map<String, Object> consumerConfiguration) {
             this.consumerFactory = new DefaultConsumerFactory<>(consumerConfiguration);
             return this;
@@ -200,7 +201,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
          * @param fetcher the {@link Fetcher} used to poll, convert and consume {@link ConsumerRecords} with
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder fetcher(Fetcher<KafkaEventMessage, K, V> fetcher) {
+        public Builder<K, V> fetcher(Fetcher<KafkaEventMessage, K, V> fetcher) {
             assertNonNull(fetcher, "Fetcher may not be null");
             this.fetcher = fetcher;
             return this;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -57,8 +57,10 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
     /**
      * Instantiate a Builder to be able to create a {@link StreamableKafkaMessageSource}.
      * <p>
-     * The {@code groupId}, {@link ConsumerFactory} and {@link Fetcher} are <b>hard requirements</b> and as such should
-     * be provided.
+     * The {@code topic} is defaulted to {@code "Axon.Events"}, the {@link KafkaMessageConverter} to a {@link
+     * DefaultKafkaMessageConverter} using the {@link XStreamSerializer} and the {@code bufferFactory} the {@link
+     * SortedKafkaMessageBuffer} constructor. The {@code groupId}, {@link ConsumerFactory} and {@link Fetcher} are
+     * <b>hard requirements</b> and as such should be provided.
      *
      * @return a Builder to be able to create an {@link StreamableKafkaMessageSource}
      */
@@ -116,8 +118,10 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
     /**
      * Builder class to instantiate a {@link StreamableKafkaMessageSource}.
      * <p>
-     * The {@code groupId}, {@link ConsumerFactory} and {@link Fetcher} are <b>hard requirements</b> and as such should
-     * be provided.
+     * The {@code topic} is defaulted to {@code "Axon.Events"}, the {@link KafkaMessageConverter} to a {@link
+     * DefaultKafkaMessageConverter} using the {@link XStreamSerializer} and the {@code bufferFactory} the {@link
+     * SortedKafkaMessageBuffer} constructor. The {@code groupId}, {@link ConsumerFactory} and {@link Fetcher} are
+     * <b>hard requirements</b> and as such should be provided.
      *
      * @param <K> the key of the {@link ConsumerRecords} to consume, fetch and convert
      * @param <V> the value type of {@link ConsumerRecords} to consume, fetch and convert

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -16,13 +16,20 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.extensions.kafka.eventhandling.DefaultKafkaMessageConverter;
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import org.axonframework.messaging.StreamableMessageSource;
+import org.axonframework.serialization.xml.XStreamSerializer;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import static org.axonframework.common.Assert.isTrue;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
@@ -32,88 +39,198 @@ import static org.axonframework.common.BuilderUtils.assertThat;
  * Implementation of the {@link StreamableMessageSource} that reads messages from a Kafka topic using the provided
  * {@link Fetcher}.
  *
+ * @param <K> the key of the {@link ConsumerRecords} to consume, fetch and convert
+ * @param <V> the value type of {@link ConsumerRecords} to consume, fetch and convert
  * @author Nakul Mishra
  * @author Steven van Beelen
  * @since 4.0
  */
-public class StreamableKafkaMessageSource implements StreamableMessageSource<TrackedEventMessage<?>> {
+public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSource<TrackedEventMessage<?>> {
 
-    private final Fetcher fetcher;
+    private final String topic;
     private final String groupId;
+    private final ConsumerFactory<K, V> consumerFactory;
+    private final Fetcher<KafkaEventMessage, K, V> fetcher;
+    private final KafkaMessageConverter<K, V> messageConverter;
+    private final Supplier<Buffer<KafkaEventMessage>> bufferFactory;
 
     /**
      * Instantiate a Builder to be able to create a {@link StreamableKafkaMessageSource}.
      * <p>
-     * The {@link Fetcher} and {@code groupId} are <b>hard requirements</b> and as such should be provided.
+     * The {@code groupId}, {@link ConsumerFactory} and {@link Fetcher} are <b>hard requirements</b> and as such should
+     * be provided.
      *
      * @return a Builder to be able to create an {@link StreamableKafkaMessageSource}
      */
-    public static Builder builder() {
-        return new Builder();
+    public static <K, V> Builder<K, V> builder() {
+        return new Builder<>();
     }
 
     /**
      * Instantiate a {@link StreamableKafkaMessageSource} based on the fields contained in the {@link Builder}.
      * <p>
-     * Will assert that the {@link Fetcher} is not {@code null} and that the {@code groupId} is a non-empty {@link
-     * String}. An {@link AxonConfigurationException} is thrown if either of both is not the case.
+     * Will assert that the {@code groupId} is a non-empty {@link String} and that the {@link ConsumerFactory} and
+     * {@link Fetcher} are not {@code null}. An {@link AxonConfigurationException} is thrown if any of them is not the
+     * case.
      *
      * @param builder the {@link Builder} used to instantiate a {@link StreamableKafkaMessageSource} instance
      */
     @SuppressWarnings("WeakerAccess")
-    protected StreamableKafkaMessageSource(Builder builder) {
+    protected StreamableKafkaMessageSource(Builder<K, V> builder) {
         builder.validate();
-        this.fetcher = builder.fetcher;
+
+        this.topic = builder.topic;
         this.groupId = builder.groupId;
+        this.consumerFactory = builder.consumerFactory;
+        this.fetcher = builder.fetcher;
+        this.messageConverter = builder.messageConverter;
+        this.bufferFactory = builder.bufferFactory;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The stream is filled by polling {@link ConsumerRecords} from the specified {@code topic} with the {@link
+     * Fetcher}. The provided {@code trackingToken} is required to be of type {@link KafkaTrackingToken}.
+     */
     @SuppressWarnings("ConstantConditions") // Verified TrackingToken type through `Assert.isTrue` operation
     @Override
     public BlockingStream<TrackedEventMessage<?>> openStream(TrackingToken trackingToken) {
-        isTrue(
-                trackingToken == null || trackingToken instanceof KafkaTrackingToken,
-                () -> "Incompatible token type provided."
-        );
+        isTrue(trackingToken == null || trackingToken instanceof KafkaTrackingToken,
+               () -> "Incompatible token type provided.");
+        KafkaTrackingToken token = ((KafkaTrackingToken) trackingToken);
 
-        return fetcher.start((KafkaTrackingToken) trackingToken, groupId);
+        Consumer<K, V> consumer = consumerFactory.createConsumer(groupId);
+        ConsumerUtil.seek(topic, consumer, token);
+
+        if (KafkaTrackingToken.isEmpty(token)) {
+            token = KafkaTrackingToken.emptyToken();
+        }
+
+        Buffer<KafkaEventMessage> buffer = bufferFactory.get();
+        Runnable closeHandler =
+                fetcher.poll(consumer, new TrackingRecordConverter<>(messageConverter, token), buffer::putAll);
+        return new KafkaMessageStream(buffer, closeHandler);
     }
 
     /**
      * Builder class to instantiate a {@link StreamableKafkaMessageSource}.
      * <p>
-     * The {@link Fetcher} and {@code groupId} are <b>hard requirements</b> and as such should be provided.
+     * The {@code groupId}, {@link ConsumerFactory} and {@link Fetcher} are <b>hard requirements</b> and as such should
+     * be provided.
+     *
+     * @param <K> the key of the {@link ConsumerRecords} to consume, fetch and convert
+     * @param <V> the value type of {@link ConsumerRecords} to consume, fetch and convert
      */
-    public static class Builder {
+    public static class Builder<K, V> {
 
-        private Fetcher fetcher;
+        private String topic = "Axon.Events";
         private String groupId;
+        private ConsumerFactory<K, V> consumerFactory;
+        private Fetcher<KafkaEventMessage, K, V> fetcher;
+        @SuppressWarnings("unchecked")
+        private KafkaMessageConverter<K, V> messageConverter =
+                (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder().serializer(
+                        XStreamSerializer.builder().build()
+                ).build();
+        private Supplier<Buffer<KafkaEventMessage>> bufferFactory = SortedKafkaMessageBuffer::new;
 
         /**
-         * Sets the {@link Fetcher} used to fetch a {@link BlockingStream} of {@link TrackedEventMessage} instances.
+         * Set the Kafka {@code topic} to read {@link org.axonframework.eventhandling.EventMessage}s from. Defaults to
+         * {@code Axon.Events}.
          *
-         * @param fetcher the {@link Fetcher} used to fetch a {@link BlockingStream} of {@link TrackedEventMessage}
-         *                instances
+         * @param topic the Kafka {@code topic} to read {@link org.axonframework.eventhandling.EventMessage}s from
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder fetcher(Fetcher fetcher) {
+        public Builder<K, V> topic(String topic) {
+            assertThat(topic, name -> Objects.nonNull(name) && !"".equals(name), "The topic may not be null or empty");
+            this.topic = topic;
+            return this;
+        }
+
+        /**
+         * Sets the Consumer {@code groupId} to which a {@link Consumer} should retrieve records from
+         *
+         * @param groupId a {@link String} defining the Consumer Group id to which a {@link Consumer} should retrieve
+         *                records from
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder groupId(String groupId) {
+            assertThat(groupId, name -> Objects.nonNull(name) && !"".equals(name),
+                       "The groupId may not be null or empty");
+            this.groupId = groupId;
+            return this;
+        }
+
+        /**
+         * Sets the {@link ConsumerFactory} to be used by this {@link StreamableKafkaMessageSource} to create {@link
+         * Consumer} instances with.
+         *
+         * @param consumerFactory a {@link ConsumerFactory} to be used by this {@link StreamableKafkaMessageSource} to
+         *                        create {@link Consumer} instances with.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<K, V> consumerFactory(ConsumerFactory<K, V> consumerFactory) {
+            assertNonNull(consumerFactory, "ConsumerFactory may not be null");
+            this.consumerFactory = consumerFactory;
+            return this;
+        }
+
+        /**
+         * Instantiate a {@link DefaultConsumerFactory} with the provided {@code consumerConfiguration}. Used by this
+         * {@link StreamableKafkaMessageSource} to create {@link Consumer} instances with.
+         *
+         * @param consumerConfiguration a {@link DefaultConsumerFactory} with the given {@code consumerConfiguration},
+         *                              to be used by this {@link StreamableKafkaMessageSource} to create {@link
+         *                              Consumer} instances with
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<K, V> consumerFactory(Map<String, Object> consumerConfiguration) {
+            this.consumerFactory = new DefaultConsumerFactory<>(consumerConfiguration);
+            return this;
+        }
+
+        /**
+         * Sets the {@link Fetcher} used to poll, convert and consume {@link ConsumerRecords} with.
+         *
+         * @param fetcher the {@link Fetcher} used to poll, convert and consume {@link ConsumerRecords} with
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder fetcher(Fetcher<KafkaEventMessage, K, V> fetcher) {
             assertNonNull(fetcher, "Fetcher may not be null");
             this.fetcher = fetcher;
             return this;
         }
 
         /**
-         * Sets the Consumer {@code groupId} from which a {@link BlockingStream} should retrieve its events from
+         * Sets the {@link KafkaMessageConverter} used to convert Kafka messages into {@link
+         * org.axonframework.eventhandling.EventMessage}s. Defaults to a {@link DefaultKafkaMessageConverter} using the
+         * {@link XStreamSerializer}.
+         * <p>
+         * Note that configuring a MessageConverter on the builder is mandatory if the value type is not {@code
+         * byte[]}.
          *
-         * @param groupId a {@link String} defining the Consumer Group id from which a {@link BlockingStream} should
-         *                retrieve its events from
+         * @param messageConverter a {@link KafkaMessageConverter} used to convert Kafka messages into {@link
+         *                         org.axonframework.eventhandling.EventMessage}s
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder groupId(String groupId) {
-            assertThat(
-                    groupId, name -> Objects.nonNull(name) && !"".equals(name),
-                    "The groupId may not be null or empty"
-            );
-            this.groupId = groupId;
+        public Builder<K, V> messageConverter(KafkaMessageConverter<K, V> messageConverter) {
+            assertNonNull(messageConverter, "MessageConverter may not be null");
+            this.messageConverter = messageConverter;
+            return this;
+        }
+
+        /**
+         * Sets the {@code bufferFactory} of type {@link Supplier} with a generic type {@link Buffer} with {@link
+         * KafkaEventMessage}s. Used to create a buffer which will consume the converted Kafka {@link ConsumerRecords}.
+         * Defaults to a {@link SortedKafkaMessageBuffer}.
+         *
+         * @param bufferFactory a {@link Supplier} to create a buffer for the Kafka records fetcher
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<K, V> bufferFactory(Supplier<Buffer<KafkaEventMessage>> bufferFactory) {
+            assertNonNull(bufferFactory, "Buffer factory may not be null");
+            this.bufferFactory = bufferFactory;
             return this;
         }
 
@@ -122,8 +239,8 @@ public class StreamableKafkaMessageSource implements StreamableMessageSource<Tra
          *
          * @return a {@link StreamableKafkaMessageSource} as specified through this Builder
          */
-        public StreamableKafkaMessageSource build() {
-            return new StreamableKafkaMessageSource(this);
+        public StreamableKafkaMessageSource<K, V> build() {
+            return new StreamableKafkaMessageSource<>(this);
         }
 
         /**
@@ -134,10 +251,10 @@ public class StreamableKafkaMessageSource implements StreamableMessageSource<Tra
          */
         @SuppressWarnings("WeakerAccess")
         protected void validate() throws AxonConfigurationException {
-            assertNonNull(fetcher, "The Fetcher is a hard requirement and should be provided");
-            assertThat(groupId,
-                       name -> Objects.nonNull(name) && !"".equals(name),
+            assertThat(groupId, name -> Objects.nonNull(name) && !"".equals(name),
                        "The groupId may not be null or empty");
+            assertNonNull(consumerFactory, "The ConsumerFactory is a hard requirement and should be provided");
+            assertNonNull(fetcher, "The Fetcher is a hard requirement and should be provided");
         }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
@@ -1,0 +1,66 @@
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.axonframework.common.Assert.nonNull;
+
+/**
+ * {@link RecordConverter} instances which keeps track of the converted {@link ConsumerRecords} through a {@link
+ * KafkaTrackingToken}. Consequently it converts the ConsumerRecords in to {@link KafkaEventMessage} instances.
+ *
+ * @param <K> the key of the Kafka {@link ConsumerRecords} to be converted
+ * @param <V> the value type of Kafka {@link ConsumerRecords} to be converted
+ * @author Steven van Beelen
+ * @since 4.0
+ */
+public class TrackingRecordConverter<K, V> implements RecordConverter<KafkaEventMessage, K, V> {
+
+    private static final Logger logger = LoggerFactory.getLogger(TrackingRecordConverter.class);
+
+    private final KafkaMessageConverter<K, V> messageConverter;
+    private KafkaTrackingToken currentToken;
+
+    /**
+     * Instantiates a {@link TrackingRecordConverter}, using the {@link KafkaMessageConverter} to convert {@link
+     * ConsumerRecord} instances in to an {@link org.axonframework.eventhandling.EventMessage} instances. As it
+     * traverses the {@link ConsumerRecords} it will advance the provided {@code token}. An {@link
+     * IllegalArgumentException} will be thrown if the provided {@code token} is {@code null}.
+     *
+     * @param messageConverter the {@link KafkaMessageConverter} used to convert a {@link ConsumerRecord} in to an
+     *                         {@link org.axonframework.eventhandling.EventMessage}
+     * @param token            the {@link KafkaTrackingToken} to advance for every fetched {@link ConsumerRecord}
+     */
+    public TrackingRecordConverter(KafkaMessageConverter<K, V> messageConverter, KafkaTrackingToken token) {
+        this.messageConverter = messageConverter;
+        this.currentToken = nonNull(token, () -> "Token may not be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * {@code E} is defined as a {@link KafkaEventMessage} for this implementation. Every {@link ConsumerRecord} will
+     * advance the defined {@code token}'s position further with the ConsumerRecord's {@link ConsumerRecord#partition()}
+     * and {@link ConsumerRecord#offset()}.
+     */
+    @Override
+    public List<KafkaEventMessage> convert(ConsumerRecords<K, V> records) {
+        List<KafkaEventMessage> eventMessages = new ArrayList<>(records.count());
+        for (ConsumerRecord<K, V> record : records) {
+            messageConverter.readKafkaMessage(record).ifPresent(eventMessage -> {
+                KafkaTrackingToken nextToken = currentToken.advancedTo(record.partition(), record.offset());
+                logger.debug("Advancing token from [{}] to [{}]", currentToken, nextToken);
+
+                currentToken = nextToken;
+                eventMessages.add(KafkaEventMessage.from(eventMessage, record, currentToken));
+            });
+        }
+        return eventMessages;
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.axonframework.common.Assert.nonNull;
+
 /**
  * {@link RecordConverter} instances which keeps track of the converted {@link ConsumerRecords} through a {@link
  * KafkaTrackingToken}. Consequently it converts the ConsumerRecords in to {@link KafkaEventMessage} instances.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -10,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.axonframework.common.Assert.nonNull;
-
 /**
  * {@link RecordConverter} instances which keeps track of the converted {@link ConsumerRecords} through a {@link
  * KafkaTrackingToken}. Consequently it converts the ConsumerRecords in to {@link KafkaEventMessage} instances.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverter.java
@@ -36,7 +36,7 @@ import static org.axonframework.common.Assert.nonNull;
  * @author Steven van Beelen
  * @since 4.0
  */
-public class TrackingRecordConverter<K, V> implements RecordConverter<KafkaEventMessage, K, V> {
+public class TrackingRecordConverter<K, V> implements RecordConverter<K, V, KafkaEventMessage> {
 
     private static final Logger logger = LoggerFactory.getLogger(TrackingRecordConverter.class);
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
@@ -47,19 +47,6 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
     private final KafkaPublisher<K, V> kafkaPublisher;
 
     /**
-     * Instantiate a {@link KafkaEventPublisher} based on the fields contained in the {@link Builder}.
-     * <p>
-     * Will assert that the {@link KafkaPublisher} is not {@code null}, and will throw an
-     * {@link AxonConfigurationException} if it is.
-     *
-     * @param builder the {@link Builder} used to instantiate a {@link KafkaEventPublisher} instance
-     */
-    protected KafkaEventPublisher(Builder<K, V> builder) {
-        builder.validate();
-        this.kafkaPublisher = builder.kafkaPublisher;
-    }
-
-    /**
      * Instantiate a Builder to be able to create a {@link KafkaEventPublisher}.
      * <p>
      * The {@link KafkaPublisher} is a <b>hard requirements</b> and as such should be provided.
@@ -70,6 +57,19 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
      */
     public static <K, V> Builder<K, V> builder() {
         return new Builder<>();
+    }
+
+    /**
+     * Instantiate a {@link KafkaEventPublisher} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@link KafkaPublisher} is not {@code null}, and will throw an
+     * {@link AxonConfigurationException} if it is.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link KafkaEventPublisher} instance
+     */
+    protected KafkaEventPublisher(Builder<K, V> builder) {
+        builder.validate();
+        this.kafkaPublisher = builder.kafkaPublisher;
     }
 
     @Override
@@ -103,7 +103,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
          *                       {@link EventMessage} on
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder kafkaPublisher(KafkaPublisher<K, V> kafkaPublisher) {
+        public Builder<K, V> kafkaPublisher(KafkaPublisher<K, V> kafkaPublisher) {
             assertNonNull(kafkaPublisher, "KafkaPublisher may not be null");
             this.kafkaPublisher = kafkaPublisher;
             return this;
@@ -114,7 +114,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
          *
          * @return a {@link KafkaEventPublisher} as specified through this Builder
          */
-        public KafkaEventPublisher build() {
+        public KafkaEventPublisher<K, V> build() {
             return new KafkaEventPublisher<>(this);
         }
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.minimal;
 import static org.junit.jupiter.api.Assertions.*;
-
 /**
  * Kafka Integration tests asserting a message can be published through a Producer on a Kafka topic and received through
  * a Consumer.

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -78,15 +78,15 @@ class KafkaIntegrationTest {
                 .producerFactory(producerFactory)
                 .topic("integration")
                 .build();
-        KafkaEventPublisher sender = KafkaEventPublisher.<String, byte[]>builder().kafkaPublisher(publisher).build();
+        KafkaEventPublisher<String, byte[]> sender =
+                KafkaEventPublisher.<String, byte[]>builder().kafkaPublisher(publisher).build();
         configurer.eventProcessing(
                 eventProcessingConfigurer -> eventProcessingConfigurer.registerEventHandler(c -> sender)
         );
 
         consumerFactory = new DefaultConsumerFactory<>(minimal(kafkaBroker, ByteArrayDeserializer.class));
 
-        //noinspection unchecked
-        fetcher = AsyncFetcher.<String, byte[]>builder()
+        fetcher = AsyncFetcher.<KafkaEventMessage, String, byte[]>builder()
                 .pollTimeout(300)
                 .build();
 
@@ -105,7 +105,6 @@ class KafkaIntegrationTest {
 
     @Test
     void testPublishAndReadMessages() throws Exception {
-        //noinspection unchecked
         StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
                 StreamableKafkaMessageSource.<String, byte[]>builder()
                         .topic("integration")

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -47,6 +47,7 @@ import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.minimal;
 import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * Kafka Integration tests asserting a message can be published through a Producer on a Kafka topic and received through
  * a Consumer.

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -68,7 +68,7 @@ class KafkaIntegrationTest {
     private EventBus eventBus;
     private ProducerFactory<String, byte[]> producerFactory;
     private KafkaPublisher<String, byte[]> publisher;
-    private Fetcher<KafkaEventMessage, String, byte[]> fetcher;
+    private Fetcher<String, byte[], KafkaEventMessage> fetcher;
     private ConsumerFactory<String, byte[]> consumerFactory;
 
     @BeforeEach
@@ -86,7 +86,7 @@ class KafkaIntegrationTest {
 
         consumerFactory = new DefaultConsumerFactory<>(minimal(kafkaBroker, ByteArrayDeserializer.class));
 
-        fetcher = AsyncFetcher.<KafkaEventMessage, String, byte[]>builder()
+        fetcher = AsyncFetcher.<String, byte[], KafkaEventMessage>builder()
                 .pollTimeout(300)
                 .build();
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -27,25 +27,26 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.AsyncFetcher;
 import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
+import org.axonframework.extensions.kafka.eventhandling.consumer.KafkaEventMessage;
 import org.axonframework.extensions.kafka.eventhandling.consumer.StreamableKafkaMessageSource;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher;
 import org.axonframework.extensions.kafka.eventhandling.producer.KafkaPublisher;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
 import org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil;
-import org.junit.*;
-import org.junit.runner.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.minimal;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Kafka Integration tests asserting a message can be published through a Producer on a Kafka topic and received through
@@ -54,10 +55,10 @@ import static org.junit.Assert.*;
  * @author Nakul Mishra
  * @author Steven van Beelen
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @DirtiesContext
 @EmbeddedKafka(topics = {"integration"}, partitions = 5, controlledShutdown = true)
-public class KafkaIntegrationTest {
+class KafkaIntegrationTest {
 
     @SuppressWarnings("SpringJavaAutowiredMembersInspection")
     @Autowired
@@ -67,10 +68,11 @@ public class KafkaIntegrationTest {
     private EventBus eventBus;
     private ProducerFactory<String, byte[]> producerFactory;
     private KafkaPublisher<String, byte[]> publisher;
-    private Fetcher fetcher;
+    private Fetcher<KafkaEventMessage, String, byte[]> fetcher;
+    private ConsumerFactory<String, byte[]> consumerFactory;
 
-    @Before
-    public void setupComponents() {
+    @BeforeEach
+    void setUp() {
         producerFactory = ProducerConfigUtil.ackProducerFactory(kafkaBroker, ByteArraySerializer.class);
         publisher = KafkaPublisher.<String, byte[]>builder()
                 .producerFactory(producerFactory)
@@ -81,12 +83,10 @@ public class KafkaIntegrationTest {
                 eventProcessingConfigurer -> eventProcessingConfigurer.registerEventHandler(c -> sender)
         );
 
-        ConsumerFactory<String, byte[]> consumerFactory =
-                new DefaultConsumerFactory<>(minimal(kafkaBroker, ByteArrayDeserializer.class));
+        consumerFactory = new DefaultConsumerFactory<>(minimal(kafkaBroker, ByteArrayDeserializer.class));
 
+        //noinspection unchecked
         fetcher = AsyncFetcher.<String, byte[]>builder()
-                .consumerFactory(consumerFactory)
-                .topic("integration")
                 .pollTimeout(300)
                 .build();
 
@@ -96,22 +96,27 @@ public class KafkaIntegrationTest {
         configurer.start();
     }
 
-    @After
-    public void shutdown() {
+    @AfterEach
+    void shutdown() {
         producerFactory.shutDown();
         fetcher.shutdown();
         publisher.shutDown();
     }
 
     @Test
-    public void testPublishAndReadMessages() throws Exception {
-        StreamableKafkaMessageSource messageSource = StreamableKafkaMessageSource.builder()
-                                                                                 .fetcher(fetcher)
-                                                                                 .groupId(DEFAULT_GROUP_ID)
-                                                                                 .build();
-        BlockingStream<TrackedEventMessage<?>> stream1 = messageSource.openStream(null);
+    void testPublishAndReadMessages() throws Exception {
+        //noinspection unchecked
+        StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
+                StreamableKafkaMessageSource.<String, byte[]>builder()
+                        .topic("integration")
+                        .groupId(DEFAULT_GROUP_ID)
+                        .consumerFactory(consumerFactory)
+                        .fetcher(fetcher)
+                        .build();
+
+        BlockingStream<TrackedEventMessage<?>> stream1 = streamableMessageSource.openStream(null);
         stream1.close();
-        BlockingStream<TrackedEventMessage<?>> stream2 = messageSource.openStream(null);
+        BlockingStream<TrackedEventMessage<?>> stream2 = streamableMessageSource.openStream(null);
 
         eventBus.publish(asEventMessage("test"));
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -67,11 +67,11 @@ class AsyncFetcherTest {
     @Autowired
     private EmbeddedKafkaBroker kafkaBroker;
 
-    private AsyncFetcher<KafkaEventMessage, String, String> testSubject;
+    private AsyncFetcher<String, String, KafkaEventMessage> testSubject;
 
     @BeforeEach
     void setUp() {
-        testSubject = AsyncFetcher.<KafkaEventMessage, String, String>builder()
+        testSubject = AsyncFetcher.<String, String, KafkaEventMessage>builder()
                 .executorService(newSingleThreadExecutor()).build();
     }
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,7 +48,6 @@ import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConf
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 /**
  * Tests for {@link AsyncFetcher}, asserting construction and utilization of the class.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -48,6 +48,7 @@ import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConf
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 /**
  * Tests for {@link AsyncFetcher}, asserting construction and utilization of the class.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -71,8 +71,8 @@ class AsyncFetcherTest {
 
     @BeforeEach
     void setUp() {
-        //noinspection unchecked
-        testSubject = AsyncFetcher.<String, String>builder().executorService(newSingleThreadExecutor()).build();
+        testSubject = AsyncFetcher.<KafkaEventMessage, String, String>builder()
+                .executorService(newSingleThreadExecutor()).build();
     }
 
     @AfterEach
@@ -215,7 +215,7 @@ class AsyncFetcherTest {
      *
      * @param <E> the type of the elements stored in this {@link Buffer} implementation
      */
-    private static class LatchedSortedKafkaMessageBuffer<E extends Comparable & KafkaRecordMetaData>
+    private static class LatchedSortedKafkaMessageBuffer<E extends Comparable<?> & KafkaRecordMetaData<?>>
             extends SortedKafkaMessageBuffer<E> {
 
         private final CountDownLatch bufferedMessageLatch;

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerRecordConverter.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerRecordConverter.java
@@ -24,6 +24,7 @@ import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import java.util.Optional;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+
 /**
  * A {@link KafkaMessageConverter} implementation solely intended to test message consumption.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerRecordConverter.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerRecordConverter.java
@@ -1,0 +1,28 @@
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
+
+import java.util.Optional;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+
+/**
+ * A {@link KafkaMessageConverter} implementation solely intended to test message consumption.
+ *
+ * @author Steven van Beelen
+ */
+class ConsumerRecordConverter implements KafkaMessageConverter<String, String> {
+
+    @Override
+    public ProducerRecord<String, String> createKafkaMessage(EventMessage<?> eventMessage, String topic) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<EventMessage<?>> readKafkaMessage(ConsumerRecord<String, String> consumerRecord) {
+        return Optional.of(asEventMessage(consumerRecord.value()));
+    }
+}

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerRecordConverter.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerRecordConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -8,7 +24,6 @@ import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
 import java.util.Optional;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-
 /**
  * A {@link KafkaMessageConverter} implementation solely intended to test message consumption.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
@@ -49,7 +49,7 @@ class FetchEventsTaskTest {
     private Duration testPollTimeout;
     private RecordConverter<KafkaEventMessage, String, String> testRecordConverter;
     private RecordConsumer<KafkaEventMessage> testRecordConsumer;
-    private java.util.function.Consumer<FetchEventsTask> testCloseHandler;
+    private java.util.function.Consumer<FetchEventsTask<KafkaEventMessage, String, String>> testCloseHandler;
     private FetchEventsTask<KafkaEventMessage, String, String> testSubject;
 
     @SuppressWarnings("unchecked")

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.axonframework.extensions.kafka.eventhandling.util.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 /**
  * Tests for the {@link FetchEventsTask}, asserting construction and utilization of the class.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.axonframework.extensions.kafka.eventhandling.util.AssertUtils.assertWithin;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 /**
  * Tests for the {@link FetchEventsTask}, asserting construction and utilization of the class.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStreamTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
+import org.axonframework.common.Registration;
 import org.axonframework.eventhandling.GenericDomainEventMessage;
 import org.axonframework.eventhandling.GenericTrackedDomainEventMessage;
 import org.axonframework.messaging.MetaData;
@@ -138,15 +139,15 @@ public class KafkaMessageStreamTest {
 
     @Test
     public void testClosingMessageStreamShouldInvokeTheCloseHandler() {
-        Runnable closeHandler = mock(Runnable.class);
+        Registration closeHandler = mock(Registration.class);
         KafkaMessageStream mock = new KafkaMessageStream(new SortedKafkaMessageBuffer<>(), closeHandler);
-        verify(closeHandler, never()).run();
+        verify(closeHandler, never()).cancel();
         mock.close();
-        verify(closeHandler).run();
+        verify(closeHandler).cancel();
     }
 
     private static KafkaMessageStream emptyStream() {
-        Runnable closeHandler = mock(Runnable.class);
+        Registration closeHandler = mock(Registration.class);
         return new KafkaMessageStream(new SortedKafkaMessageBuffer<>(), closeHandler);
     }
 
@@ -166,7 +167,7 @@ public class KafkaMessageStreamTest {
             buffer.put(new KafkaEventMessage(messages.get(i), 0, i, 1));
         }
 
-        Runnable closeHandler = mock(Runnable.class);
+        Registration closeHandler = mock(Registration.class);
         return new KafkaMessageStream(buffer, closeHandler);
     }
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2019. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import static org.axonframework.extensions.kafka.eventhandling.consumer.KafkaTra
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 /**
  * Tests for {@link StreamableKafkaMessageSource}, asserting construction and utilization of the class.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
@@ -16,12 +16,17 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.common.stream.BlockingStream;
 import org.axonframework.eventhandling.TrackingToken;
-import org.junit.*;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.axonframework.extensions.kafka.eventhandling.consumer.KafkaTrackingToken.emptyToken;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -30,52 +35,104 @@ import static org.mockito.Mockito.*;
  * @author Nakul Mishra
  * @author Steven van Beelen
  */
-public class StreamableKafkaMessageSourceTest {
+class StreamableKafkaMessageSourceTest {
 
-    private Fetcher fetcher = mock(Fetcher.class);
+    private ConsumerFactory<String, String> consumerFactory;
+    private Fetcher<KafkaEventMessage, String, String> fetcher;
 
     private StreamableKafkaMessageSource testSubject;
 
-    @Before
-    public void setUp() {
-        testSubject = StreamableKafkaMessageSource.builder()
-                                                  .fetcher(fetcher)
-                                                  .groupId(DEFAULT_GROUP_ID)
-                                                  .build();
-    }
+    private Consumer<String, String> mockConsumer;
 
-    @Test(expected = AxonConfigurationException.class)
-    public void testBuildingStreamableKafkaMessageSourceMissingRequiredFieldsShouldThrowAxonConfigurationException() {
-        StreamableKafkaMessageSource.builder().build();
-    }
+    @SuppressWarnings("unchecked")
+    @BeforeEach
+    void setUp() {
+        consumerFactory = mock(ConsumerFactory.class);
+        mockConsumer = mock(Consumer.class);
+        when(consumerFactory.createConsumer(DEFAULT_GROUP_ID)).thenReturn(mockConsumer);
+        fetcher = mock(Fetcher.class);
 
-    @Test(expected = AxonConfigurationException.class)
-    public void testBuildingStreamableKafkaMessageSourceUsingInvalidFetcherShouldThrowAxonConfigurationException() {
-        StreamableKafkaMessageSource.builder().fetcher(null);
-    }
-
-    @Test(expected = AxonConfigurationException.class)
-    public void testBuildingStreamableKafkaMessageSourceUsingInvalidGroupIdShouldThrowAxonConfigurationException() {
-        StreamableKafkaMessageSource.builder().groupId(null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testOpeningMessageStreamWithInvalidTypeOfTrackingTokenShouldThrowException() {
-        testSubject.openStream(incompatibleTokenType());
+        testSubject = StreamableKafkaMessageSource.<String, String>builder()
+                .groupId(DEFAULT_GROUP_ID)
+                .consumerFactory(consumerFactory)
+                .fetcher(fetcher)
+                .build();
     }
 
     @Test
-    public void testOpeningMessageStreamWithNullTokenShouldInvokeFetcher() {
-        testSubject.openStream(null);
-
-        verify(fetcher, times(1)).start(any(), eq(DEFAULT_GROUP_ID));
+    void testBuildingWithInvalidTopicShouldThrowAxonConfigurationException() {
+        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().topic(null));
     }
 
     @Test
-    public void testOpeningMessageStreamWithValidTokenShouldStartTheFetcher() {
-        testSubject.openStream(emptyToken());
+    void testBuildingWithInvalidGroupIdShouldThrowAxonConfigurationException() {
+        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().groupId(null));
+    }
 
-        verify(fetcher, times(1)).start(any(), eq(DEFAULT_GROUP_ID));
+    @Test
+    void testBuildingWithInvalidConsumerFactoryShouldThrowAxonConfigurationException() {
+        //noinspection unchecked
+        assertThrows(
+                AxonConfigurationException.class,
+                () -> StreamableKafkaMessageSource.builder().consumerFactory((ConsumerFactory) null)
+        );
+    }
+
+    @Test
+    void testBuildingWithInvalidFetcherShouldThrowAxonConfigurationException() {
+        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().fetcher(null));
+    }
+
+    @Test
+    void testBuildingWithInvalidMessageConverterShouldThrowAxonConfigurationException() {
+        assertThrows(
+                AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().messageConverter(null)
+        );
+    }
+
+    @Test
+    void testBuildingWithInvalidBufferFactoryShouldThrowAxonConfigurationException() {
+        assertThrows(
+                AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().bufferFactory(null)
+        );
+    }
+
+    @Test
+    void testBuildingWhilstMissingRequiredFieldsShouldThrowAxonConfigurationException() {
+        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().build());
+    }
+
+    @Test
+    void testOpeningMessageStreamWithInvalidTypeOfTrackingTokenShouldThrowException() {
+        assertThrows(IllegalArgumentException.class, () -> testSubject.openStream(incompatibleTokenType()));
+    }
+
+    @Test
+    void testOpeningMessageStreamWithNullTokenShouldInvokeFetcher() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> closed.set(true));
+
+        BlockingStream result = testSubject.openStream(null);
+
+        verify(consumerFactory).createConsumer(DEFAULT_GROUP_ID);
+        verify(fetcher).poll(eq(mockConsumer), any(), any());
+
+        result.close();
+        assertTrue(closed.get());
+    }
+
+    @Test
+    void testOpeningMessageStreamWithValidTokenShouldStartTheFetcher() {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> closed.set(true));
+
+        BlockingStream result = testSubject.openStream(emptyToken());
+
+        verify(consumerFactory).createConsumer(DEFAULT_GROUP_ID);
+        verify(fetcher).poll(eq(mockConsumer), any(), any());
+
+        result.close();
+        assertTrue(closed.get());
     }
 
     private static TrackingToken incompatibleTokenType() {

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
@@ -28,6 +28,7 @@ import static org.axonframework.extensions.kafka.eventhandling.consumer.KafkaTra
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 /**
  * Tests for {@link StreamableKafkaMessageSource}, asserting construction and utilization of the class.
  *

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -16,7 +32,6 @@ import java.util.Optional;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 /**
  * Test cases to verify the {@link TrackingRecordConverter} uses the provided {@link KafkaMessageConverter} upon the
  * {@link TrackingRecordConverter#convert(ConsumerRecords)} call and that the entries track progress in the {@link

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverterTest.java
@@ -1,0 +1,91 @@
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.axonframework.eventhandling.TrackingToken;
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test cases to verify the {@link TrackingRecordConverter} uses the provided {@link KafkaMessageConverter} upon the
+ * {@link TrackingRecordConverter#convert(ConsumerRecords)} call and that the entries track progress in the {@link
+ * TrackingToken}.
+ *
+ * @author Steven van Beelen
+ */
+class TrackingRecordConverterTest {
+
+    private static final String TEST_TOPIC = "some-topic";
+    private static final int TEST_PARTITION = 0;
+
+    private KafkaMessageConverter<String, String> messageConverter;
+
+    private TrackingRecordConverter<String, String> testSubject;
+
+    @BeforeEach
+    void setUp() {
+        //noinspection unchecked
+        messageConverter = mock(KafkaMessageConverter.class);
+        when(messageConverter.readKafkaMessage(any()))
+                .thenAnswer(it -> Optional.of(asEventMessage(((ConsumerRecord) it.getArgument(0)).value())));
+
+        testSubject = new TrackingRecordConverter<>(messageConverter, KafkaTrackingToken.emptyToken());
+    }
+
+    @Test
+    void testProvidingNullTokenThrowsAssertionException() {
+        //noinspection unchecked
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TrackingRecordConverter(mock(KafkaMessageConverter.class), null)
+        );
+    }
+
+    @Test
+    void testConverterConvertsRecordsAndTracksProgress() {
+        int expectedNumberOfRecords = 42;
+        int expectedOffset = expectedNumberOfRecords - 1;
+
+        ConsumerRecords<String, String> testRecords = buildConsumerRecords(expectedNumberOfRecords);
+
+        List<KafkaEventMessage> result = testSubject.convert(testRecords);
+
+        verify(messageConverter, times(expectedNumberOfRecords)).readKafkaMessage(any());
+        assertEquals(expectedNumberOfRecords, result.size());
+
+        KafkaEventMessage lastResult = result.get(result.size() - 1);
+        assertEquals(TEST_PARTITION, lastResult.partition());
+        assertEquals(expectedOffset, lastResult.offset());
+
+        TrackingToken lastResultToken = lastResult.value().trackingToken();
+        assertTrue(lastResultToken instanceof KafkaTrackingToken);
+        Map<Integer, Long> partitionPositions = ((KafkaTrackingToken) lastResultToken).partitionPositions();
+        assertEquals(1, partitionPositions.size());
+        assertEquals(expectedOffset, partitionPositions.get(TEST_PARTITION));
+    }
+
+    private static ConsumerRecords<String, String> buildConsumerRecords(int numberOfRecords) {
+        List<ConsumerRecord<String, String>> consumerRecordList = new ArrayList<>();
+        for (int i = 0; i < numberOfRecords; i++) {
+            consumerRecordList.add(buildRecord(i));
+        }
+        return new ConsumerRecords<>(Collections.singletonMap(
+                new TopicPartition(TEST_TOPIC, TEST_PARTITION), consumerRecordList
+        ));
+    }
+
+    private static ConsumerRecord<String, String> buildRecord(int offset) {
+        return new ConsumerRecord<>(TEST_TOPIC, TEST_PARTITION, offset, "record-key", "record-value-" + offset);
+    }
+}

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/TrackingRecordConverterTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 /**
  * Test cases to verify the {@link TrackingRecordConverter} uses the provided {@link KafkaMessageConverter} upon the
  * {@link TrackingRecordConverter#convert(ConsumerRecords)} call and that the entries track progress in the {@link

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTest.java
@@ -148,7 +148,7 @@ public class KafkaPublisherTest {
         String testTopic = "testSendMessagesAckNoUnitOfWorkWithTimeout";
         testProducerFactory = mock(DefaultProducerFactory.class);
         when(testProducerFactory.confirmationMode()).thenReturn(ConfirmationMode.WAIT_FOR_ACK);
-        Producer testProducer = mock(Producer.class);
+        Producer<String, byte[]> testProducer = mock(Producer.class);
         when(testProducerFactory.createProducer()).thenReturn(testProducer);
 
         Future<RecordMetadata> timeoutFuture1 = new CompletableFuture<>();
@@ -264,13 +264,14 @@ public class KafkaPublisherTest {
         publishWithException(testTopic, testMessage);
     }
 
+    @SuppressWarnings("unchecked")
     private static DefaultProducerFactory<String, byte[]> producerFactoryWithFencedExceptionOnBeginTransaction() {
-        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class, "FactoryForExceptionOnBeginTx");
-        Producer producer = mock(Producer.class, "ExceptionOnBeginTxMock");
+        DefaultProducerFactory<String, byte[]> producerFactory =
+                mock(DefaultProducerFactory.class, "FactoryForExceptionOnBeginTx");
+        Producer<String, byte[]> producer = mock(Producer.class, "ExceptionOnBeginTxMock");
         when(producerFactory.confirmationMode()).thenReturn(ConfirmationMode.TRANSACTIONAL);
         when(producerFactory.createProducer()).thenReturn(producer);
         doThrow(ProducerFencedException.class).when(producer).beginTransaction();
-        //noinspection unchecked
         return producerFactory;
     }
 
@@ -284,13 +285,13 @@ public class KafkaPublisherTest {
         publishWithException(testTopic, testMessage);
     }
 
+    @SuppressWarnings("unchecked")
     private static DefaultProducerFactory<String, byte[]> producerFactoryWithFencedExceptionOnCommit() {
-        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class);
-        Producer producer = mock(Producer.class, "ExceptionOnCommitTxMock");
+        DefaultProducerFactory<String, byte[]> producerFactory = mock(DefaultProducerFactory.class);
+        Producer<String, byte[]> producer = mock(Producer.class, "ExceptionOnCommitTxMock");
         when(producerFactory.confirmationMode()).thenReturn(ConfirmationMode.TRANSACTIONAL);
         when(producerFactory.createProducer()).thenReturn(producer);
         doThrow(ProducerFencedException.class).when(producer).commitTransaction();
-        //noinspection unchecked
         return producerFactory;
     }
 
@@ -322,13 +323,14 @@ public class KafkaPublisherTest {
         assertTrue("Didn't expect any consumer records", KafkaTestUtils.getRecords(testConsumer, 100).isEmpty());
     }
 
+    @SuppressWarnings("unchecked")
     private static DefaultProducerFactory<String, byte[]> producerFactoryWithFencedExceptionOnAbort() {
-        DefaultProducerFactory producerFactory = mock(DefaultProducerFactory.class, "FactoryForExceptionOnAbortTx");
-        Producer producer = mock(Producer.class, "ExceptionOnAbortTx");
+        DefaultProducerFactory<String, byte[]> producerFactory =
+                mock(DefaultProducerFactory.class, "FactoryForExceptionOnAbortTx");
+        Producer<String, byte[]> producer = mock(Producer.class, "ExceptionOnAbortTx");
         when(producerFactory.confirmationMode()).thenReturn(ConfirmationMode.TRANSACTIONAL);
         when(producerFactory.createProducer()).thenReturn(producer);
         doThrow(RuntimeException.class).when(producer).abortTransaction();
-        //noinspection unchecked
         return producerFactory;
     }
 
@@ -344,7 +346,7 @@ public class KafkaPublisherTest {
                 .topic(topic)
                 .publisherAckTimeout(1000)
                 .build();
-        KafkaEventPublisher kafkaEventPublisher =
+        KafkaEventPublisher<String, byte[]> kafkaEventPublisher =
                 KafkaEventPublisher.<String, byte[]>builder().kafkaPublisher(kafkaPublisher).build();
         /*
          * Simulate configuration.

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/AssertUtils.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/AssertUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2010-2019. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.util;
+
+import java.time.Duration;
+
+/**
+ * Utility class for special assertions
+ */
+public class AssertUtils {
+
+    private AssertUtils() {
+        // Utility class
+    }
+
+    /**
+     * Assert that the given {@code assertion} succeeds with the given {@code time} and {@code unit}.
+     *
+     * @param duration  The time in which the assertion must pass
+     * @param assertion the assertion to succeed within the deadline
+     */
+    public static void assertWithin(Duration duration, Runnable assertion) {
+        long now = System.currentTimeMillis();
+        long deadline = now + duration.toMillis();
+        do {
+            try {
+                assertion.run();
+                break;
+            } catch (AssertionError e) {
+                Thread.yield();
+                if (now >= deadline) {
+                    throw e;
+                }
+            }
+            now = System.currentTimeMillis();
+        } while (true);
+    }
+}

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/AssertUtils.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/AssertUtils.java
@@ -17,6 +17,7 @@
 package org.axonframework.extensions.kafka.eventhandling.util;
 
 import java.time.Duration;
+
 /**
  * Utility class for special assertions.
  */

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/AssertUtils.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/AssertUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,8 @@
 package org.axonframework.extensions.kafka.eventhandling.util;
 
 import java.time.Duration;
-
 /**
- * Utility class for special assertions
+ * Utility class for special assertions.
  */
 public class AssertUtils {
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,16 +109,18 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
+        <!-- Main -->
         <axon.version>4.0.4</axon.version>
         <kafka.version>2.3.0</kafka.version>
-
+        <!-- Spring -->
         <spring.version>5.1.9.RELEASE</spring.version>
         <spring.boot.version>2.1.7.RELEASE</spring.boot.version>
-
+        <!-- Logging -->
         <slf4j.version>1.7.28</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
-
+        <!-- Testing -->
+        <junit4.version>4.12</junit4.version>
+        <junit.jupiter.version>5.5.2</junit.jupiter.version>
         <mockito.version>3.0.0</mockito.version>
     </properties>
 
@@ -130,17 +132,7 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
@@ -183,6 +175,44 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit4.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
@@ -216,9 +246,27 @@
                 <artifactId>spring-boot-starter</artifactId>
                 <version>${spring.boot.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit4.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The current `Fetcher` set up is harshly tied to a event Tracking solution due to it's usage of a `KafkaEventMessage` (which expects a `TrackedEventMessage`) and the `KafkaTrackingToken`. 

The `Fetcher` interface, together with the `AsyncFetcher` implementation and the `FetchEventsTask` are however perfectly valid classes to use for general Consumer Record fetching, regardless of whether the users will Track these message or Subscribes to them.

To that end, this PR adjusts the `Fetcher` to expect a `Consumer`, `RecordConverter` and `RecordConsumer` parameter, returning a `Runnable` to close the task.
This switch moves the logic to track messages upon conversion and add them to a `BlockingStream` on consumption to the `StreamableKafkaMessageSource`, instead of having it smeared out over the `AsyncFetcher` and `FetchEventsTask`.

Last point of interest is that this PR changes testing from JUnit4 to JUnit5.

This PR is only a partial solution towards #17, as it does not yet introduce a `SubscribableKafkaMessageSource` implementation.