### PR TITLE
[#17 - Part 2] Define a Group Id prefix and suffix factory

### DIFF
--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extension/kafka/example/KafkaAxonExampleApplication.kt
@@ -20,8 +20,7 @@ import org.axonframework.eventhandling.tokenstore.inmemory.InMemoryTokenStore
 import org.axonframework.eventsourcing.eventstore.EmbeddedEventStore
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine
 import org.axonframework.extensions.kafka.KafkaProperties
-import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter
-import org.axonframework.extensions.kafka.eventhandling.consumer.*
+import org.axonframework.extensions.kafka.eventhandling.consumer.StreamableKafkaMessageSource
 import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode
 import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
@@ -71,18 +70,7 @@ class KafkaAxonExampleApplication {
 
     @Autowired
     fun configureKafkaSourceForProcessingGroup(configurer: EventProcessingConfigurer,
-                                               kafkaProperties: KafkaProperties,
-                                               consumerFactory: ConsumerFactory<String, ByteArray>,
-                                               fetcher: Fetcher<KafkaEventMessage, String, ByteArray>,
-                                               kafkaMessageConverter: KafkaMessageConverter<String, ByteArray>) {
-        val streamableKafkaMessageSource = StreamableKafkaMessageSource.builder<String, ByteArray>()
-                .topic(kafkaProperties.defaultTopic)
-                .groupId("kafka-group")
-                .consumerFactory(consumerFactory)
-                .fetcher(fetcher)
-                .messageConverter(kafkaMessageConverter)
-                .bufferFactory { SortedKafkaMessageBuffer<KafkaEventMessage>(kafkaProperties.fetcher.bufferSize) }
-                .build()
+                                               streamableKafkaMessageSource: StreamableKafkaMessageSource<String, ByteArray>) {
         configurer.registerTrackingEventProcessor("kafka-group") { streamableKafkaMessageSource }
     }
 }

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -162,7 +162,7 @@ public class KafkaAutoConfiguration {
     @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class, Fetcher.class})
     public StreamableKafkaMessageSource<String, byte[]> streamableKafkaMessageSource(
             ConsumerFactory<String, byte[]> kafkaConsumerFactory,
-            Fetcher<KafkaEventMessage, String, byte[]> kafkaFetcher,
+            Fetcher<String, byte[], KafkaEventMessage> kafkaFetcher,
             KafkaMessageConverter<String, byte[]> kafkaMessageConverter
     ) {
         return StreamableKafkaMessageSource.<String, byte[]>builder()

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -162,14 +162,13 @@ public class KafkaAutoConfiguration {
     @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class, Fetcher.class})
     public StreamableKafkaMessageSource<String, byte[]> streamableKafkaMessageSource(
             ConsumerFactory<String, byte[]> kafkaConsumerFactory,
-            Fetcher<KafkaEventMessage, String, byte[]> fetcher,
+            Fetcher<KafkaEventMessage, String, byte[]> kafkaFetcher,
             KafkaMessageConverter<String, byte[]> kafkaMessageConverter
     ) {
-        //noinspection unchecked
         return StreamableKafkaMessageSource.<String, byte[]>builder()
                 .topic(properties.getDefaultTopic())
                 .consumerFactory(kafkaConsumerFactory)
-                .fetcher(fetcher)
+                .fetcher(kafkaFetcher)
                 .messageConverter(kafkaMessageConverter)
                 .bufferFactory(() -> new SortedKafkaMessageBuffer<>(properties.getFetcher().getBufferSize()))
                 .build();

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationTest.java
@@ -90,7 +90,7 @@ class KafkaAutoConfigurationTest {
             assertNotNull(context.getBeanNamesForType(StreamableKafkaMessageSource.class));
 
             // Producer assertions
-            DefaultProducerFactory producerFactory =
+            DefaultProducerFactory<?, ?> producerFactory =
                     ((DefaultProducerFactory<?, ?>) context.getBean(DefaultProducerFactory.class));
             Map<String, Object> producerConfigs =
                     ((DefaultProducerFactory<?, ?>) context.getBean(DefaultProducerFactory.class))
@@ -312,10 +312,10 @@ class KafkaAutoConfigurationTest {
             return mock(EventBus.class);
         }
 
-        @SuppressWarnings("unchecked")
         @Bean
         public AxonConfiguration axonConfiguration() {
             AxonConfiguration mock = mock(AxonConfiguration.class);
+            //noinspection unchecked,rawtypes
             when(mock.messageMonitor(any(), any())).thenReturn((MessageMonitor) NoOpMessageMonitor.instance());
             return mock;
         }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStream.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStream.java
@@ -95,7 +95,7 @@ public class KafkaMessageStream implements TrackingEventStream {
     @Override
     public void close() {
         if (closeHandler != null) {
-            closeHandler.cancel();
+            closeHandler.close();
         }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSource.java
@@ -68,7 +68,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
      * Instantiate a Builder to be able to create a {@link StreamableKafkaMessageSource}.
      * <p>
      * The {@code topic} is defaulted to {@code "Axon.Events"}, {@code groupIdPrefix} defaults to {@code
-     * "Axon.Events.Consumer-"} and it's {@code groupIdSuffixFactory} to a {@link UUID#randomUUID()} operation, the
+     * "Axon.Streamable.Consumer-"} and it's {@code groupIdSuffixFactory} to a {@link UUID#randomUUID()} operation, the
      * {@link KafkaMessageConverter} to a {@link DefaultKafkaMessageConverter} using the {@link XStreamSerializer} and
      * the {@code bufferFactory} the {@link SortedKafkaMessageBuffer} constructor. The {@link ConsumerFactory} and
      * {@link Fetcher} are <b>hard requirements</b> and as such should be provided.
@@ -134,7 +134,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
      * Builder class to instantiate a {@link StreamableKafkaMessageSource}.
      * <p>
      * The {@code topic} is defaulted to {@code "Axon.Events"}, {@code groupIdPrefix} defaults to {@code
-     * "Axon.Events.Consumer-"} and it's {@code groupIdSuffixFactory} to a {@link UUID#randomUUID()} operation, the
+     * "Axon.Streamable.Consumer-"} and it's {@code groupIdSuffixFactory} to a {@link UUID#randomUUID()} operation, the
      * {@link KafkaMessageConverter} to a {@link DefaultKafkaMessageConverter} using the {@link XStreamSerializer} and
      * the {@code bufferFactory} the {@link SortedKafkaMessageBuffer} constructor. The {@link ConsumerFactory} and
      * {@link Fetcher} are <b>hard requirements</b> and as such should be provided.
@@ -145,7 +145,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
     public static class Builder<K, V> {
 
         private String topic = "Axon.Events";
-        private String groupIdPrefix = "Axon.Events.Consumer-";
+        private String groupIdPrefix = "Axon.Streamable.Consumer-";
         private Supplier<String> groupIdSuffixFactory = () -> UUID.randomUUID().toString();
         private ConsumerFactory<K, V> consumerFactory;
         private Fetcher<KafkaEventMessage, K, V> fetcher;
@@ -170,7 +170,8 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
         }
 
         /**
-         * Sets the prefix of the Consumer {@code groupId} from which a {@link Consumer} should retrieve records from
+         * Sets the prefix of the Consumer {@code groupId} from which a {@link Consumer} should retrieve records from.
+         * Defaults to {@code "Axon.Streamable.Consumer-"}.
          *
          * @param groupIdPrefix a {@link String} defining the prefix of  the Consumer Group id to which a {@link
          *                      Consumer} should retrieve records from

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -44,7 +44,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
-import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.minimal;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -86,9 +85,9 @@ class KafkaIntegrationTest {
         consumerFactory = new DefaultConsumerFactory<>(minimal(kafkaBroker, ByteArrayDeserializer.class));
 
         //noinspection unchecked
-        fetcher = AsyncFetcher.<String, byte[]>builder()
-                .pollTimeout(300)
-                .build();
+        fetcher = AsyncFetcher.builder()
+                              .pollTimeout(300)
+                              .build();
 
         eventBus = SimpleEventBus.builder().build();
         configurer.configureEventBus(configuration -> eventBus);
@@ -109,7 +108,6 @@ class KafkaIntegrationTest {
         StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
                 StreamableKafkaMessageSource.<String, byte[]>builder()
                         .topic("integration")
-                        .groupId(DEFAULT_GROUP_ID)
                         .consumerFactory(consumerFactory)
                         .fetcher(fetcher)
                         .build();

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStreamTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/KafkaMessageStreamTest.java
@@ -141,9 +141,9 @@ public class KafkaMessageStreamTest {
     public void testClosingMessageStreamShouldInvokeTheCloseHandler() {
         Registration closeHandler = mock(Registration.class);
         KafkaMessageStream mock = new KafkaMessageStream(new SortedKafkaMessageBuffer<>(), closeHandler);
-        verify(closeHandler, never()).cancel();
+        verify(closeHandler, never()).close();
         mock.close();
-        verify(closeHandler).cancel();
+        verify(closeHandler).close();
     }
 
     private static KafkaMessageStream emptyStream() {

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/StreamableKafkaMessageSourceTest.java
@@ -19,6 +19,7 @@ package org.axonframework.extensions.kafka.eventhandling.consumer;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.stream.BlockingStream;
+import org.axonframework.eventhandling.TrackedEventMessage;
 import org.axonframework.eventhandling.TrackingToken;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -44,7 +45,7 @@ class StreamableKafkaMessageSourceTest {
     private ConsumerFactory<String, String> consumerFactory;
     private Fetcher<KafkaEventMessage, String, String> fetcher;
 
-    private StreamableKafkaMessageSource testSubject;
+    private StreamableKafkaMessageSource<String, String> testSubject;
 
     private Consumer<String, String> mockConsumer;
 
@@ -87,7 +88,7 @@ class StreamableKafkaMessageSourceTest {
 
     @Test
     void testBuildingWithInvalidConsumerFactoryShouldThrowAxonConfigurationException() {
-        //noinspection unchecked
+        //noinspection unchecked,rawtypes
         assertThrows(
                 AxonConfigurationException.class,
                 () -> StreamableKafkaMessageSource.builder().consumerFactory((ConsumerFactory) null)
@@ -129,8 +130,7 @@ class StreamableKafkaMessageSourceTest {
         String testSuffix = "group-id-suffix";
         when(consumerFactory.createConsumer(testPrefix + testSuffix)).thenReturn(mockConsumer);
 
-        //noinspection unchecked
-        StreamableKafkaMessageSource<String, byte[]> testSubject = StreamableKafkaMessageSource.<String, String>builder()
+        StreamableKafkaMessageSource<String, String> testSubject = StreamableKafkaMessageSource.<String, String>builder()
                 .groupIdPrefix(testPrefix)
                 .groupIdSuffixFactory(() -> testSuffix)
                 .consumerFactory(consumerFactory)
@@ -153,7 +153,7 @@ class StreamableKafkaMessageSourceTest {
         AtomicBoolean closed = new AtomicBoolean(false);
         when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> closed.set(true));
 
-        BlockingStream result = testSubject.openStream(null);
+        BlockingStream<TrackedEventMessage<?>> result = testSubject.openStream(null);
 
         verify(consumerFactory).createConsumer(GROUP_ID_PREFIX + GROUP_ID_SUFFIX);
         verify(fetcher).poll(eq(mockConsumer), any(), any());
@@ -167,7 +167,7 @@ class StreamableKafkaMessageSourceTest {
         AtomicBoolean closed = new AtomicBoolean(false);
         when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> closed.set(true));
 
-        BlockingStream result = testSubject.openStream(emptyToken());
+        BlockingStream<TrackedEventMessage<?>> result = testSubject.openStream(emptyToken());
 
         verify(consumerFactory).createConsumer(GROUP_ID_PREFIX + GROUP_ID_SUFFIX);
         verify(fetcher).poll(eq(mockConsumer), any(), any());


### PR DESCRIPTION
For the `StreamableKafkaMessageSource` to support Axon's idea of segregating Event streams through the `TrackingEventProcessor` and the `SequeningPolicy`, each opened stream should be ensured to receive **all** the events from the source.

To that end, a unique Consumer Group ID should be used, always, which initially was a user concern.
With this PR, the `StreamableKafkaMessageSource` has the notion of a `groupdIdPrefix` and a `groupIdSuffixFactory`. The prefix ensures Kafka clearly shows the Axon consumer groups on top, whilst the suffix factory ensures no single `StreamableKafkaMessageSource#openStream(TrackingToken)` call will tap in to an already existing Consumer Group.

The prefix defaults to `Axon.Events.Consumer-`, and the suffix factory to `UUID#randomUUID#toString`. Both are adjustable through the `StreamableKafkaMessageSource.Builder`.

This PR is only a partial solution towards #17, as it does not yet introduce a `SubscribableKafkaMessageSource` implementation.