### PR TITLE
[#28] Use TopicPartition as the key for storing offsets

### DIFF
--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
@@ -167,7 +168,7 @@ public class KafkaAutoConfiguration {
             KafkaMessageConverter<String, byte[]> kafkaMessageConverter
     ) {
         return StreamableKafkaMessageSource.<String, byte[]>builder()
-                .topic(properties.getDefaultTopic())
+                .topics(Collections.singletonList(properties.getDefaultTopic()))
                 .consumerFactory(kafkaConsumerFactory)
                 .fetcher(kafkaFetcher)
                 .messageConverter(kafkaMessageConverter)

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/KafkaTrackingToken.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/KafkaTrackingToken.java
@@ -40,23 +40,22 @@ import static org.axonframework.common.Assert.isTrue;
  */
 public class KafkaTrackingToken implements TrackingToken, Serializable {
 
-    private final Map<TopicPartition, Long> tokenPartitionPositions;
+    private final Map<TopicPartition, Long> positions;
 
-    private KafkaTrackingToken(Map<TopicPartition, Long> tokenPartitionPositions) {
-        this.tokenPartitionPositions = Collections.unmodifiableMap(new HashMap<>(tokenPartitionPositions));
+    private KafkaTrackingToken(Map<TopicPartition, Long> positions) {
+        this.positions = Collections.unmodifiableMap(new HashMap<>(positions));
     }
 
     /**
      * Returns a new {@link KafkaTrackingToken} instance based on the given {@code partitionPositions}.
      *
-     * @param tokenPartitionPositions a {@link Map} from {@link Integer} to {@link Long}, specifying the offset of every
+     * @param positions a {@link Map} from {@link Integer} to {@link Long}, specifying the offset of every
      *                                partition
      * @return a new tracking token based on the given {@code partitionPositions}
      */
     @JsonCreator
-    public static KafkaTrackingToken newInstance(
-            @JsonProperty("tokenPartitionPositions") Map<TopicPartition, Long> tokenPartitionPositions) {
-        return new KafkaTrackingToken(tokenPartitionPositions);
+    public static KafkaTrackingToken newInstance(@JsonProperty("positions") Map<TopicPartition, Long> positions) {
+        return new KafkaTrackingToken(positions);
     }
 
     /**
@@ -85,7 +84,7 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
      * @return {@code true} if the given {@code token} is {@code null} or empty and {@code false} if it isn't
      */
     public static boolean isEmpty(KafkaTrackingToken token) {
-        return token == null || token.tokenPartitionPositions.isEmpty();
+        return token == null || token.positions.isEmpty();
     }
 
     /**
@@ -111,8 +110,8 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
      *
      * @return the {@link TopicPartition}/offset {@link Map} stored in this {@link TrackingToken}
      */
-    public Map<TopicPartition, Long> tokenPartitionPositions() {
-        return tokenPartitionPositions;
+    public Map<TopicPartition, Long> positions() {
+        return positions;
     }
 
     /**
@@ -134,9 +133,9 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
     }
 
     private KafkaTrackingToken advancedTo(TopicPartition topicPartition, long offset) {
-        Map<TopicPartition, Long> updatedPartitionPositions = new HashMap<>(tokenPartitionPositions());
-        updatedPartitionPositions.put(topicPartition, offset);
-        return new KafkaTrackingToken(updatedPartitionPositions);
+        Map<TopicPartition, Long> updatedPositions = new HashMap<>(positions());
+        updatedPositions.put(topicPartition, offset);
+        return new KafkaTrackingToken(updatedPositions);
     }
 
     @Override
@@ -154,13 +153,13 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
     }
 
     private Map<TopicPartition, Long> bounds(KafkaTrackingToken other, BiFunction<Long, Long, Long> boundsFunction) {
-        Map<TopicPartition, Long> intersection = new HashMap<>(tokenPartitionPositions());
-        other.tokenPartitionPositions().forEach(intersection::putIfAbsent);
+        Map<TopicPartition, Long> intersection = new HashMap<>(positions());
+        other.positions().forEach(intersection::putIfAbsent);
 
         intersection.keySet()
                     .forEach(topicPartition -> intersection.put(topicPartition, boundsFunction.apply(
-                            this.tokenPartitionPositions().getOrDefault(topicPartition, 0L),
-                            other.tokenPartitionPositions().getOrDefault(topicPartition, 0L))
+                            this.positions().getOrDefault(topicPartition, 0L),
+                            other.positions().getOrDefault(topicPartition, 0L))
                     ));
         return intersection;
     }
@@ -171,13 +170,13 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
         //noinspection ConstantConditions - Verified cast through `Assert.isTrue` operation
         KafkaTrackingToken otherToken = (KafkaTrackingToken) other;
 
-        return otherToken.tokenPartitionPositions()
+        return otherToken.positions()
                          .entrySet().stream()
                          .allMatch(offsetsEntry -> match(offsetsEntry.getKey(), offsetsEntry.getValue()));
     }
 
     private boolean match(TopicPartition otherTopicPartition, long otherOffset) {
-        return otherOffset <= this.tokenPartitionPositions().getOrDefault(otherTopicPartition, -1L);
+        return otherOffset <= this.positions().getOrDefault(otherTopicPartition, -1L);
     }
 
     @Override
@@ -189,18 +188,18 @@ public class KafkaTrackingToken implements TrackingToken, Serializable {
             return false;
         }
         KafkaTrackingToken that = (KafkaTrackingToken) o;
-        return Objects.equals(tokenPartitionPositions, that.tokenPartitionPositions);
+        return Objects.equals(positions, that.positions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tokenPartitionPositions);
+        return Objects.hash(positions);
     }
 
     @Override
     public String toString() {
         return "KafkaTrackingToken{" +
-                "tokenPartitionPositions=" + tokenPartitionPositions +
+                "positions=" + positions +
                 '}';
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingRecordConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingRecordConverter.java
@@ -71,7 +71,8 @@ public class TrackingRecordConverter<K, V> implements RecordConverter<K, V, Kafk
         List<KafkaEventMessage> eventMessages = new ArrayList<>(records.count());
         for (ConsumerRecord<K, V> record : records) {
             messageConverter.readKafkaMessage(record).ifPresent(eventMessage -> {
-                KafkaTrackingToken nextToken = currentToken.advancedTo(record.partition(), record.offset());
+                KafkaTrackingToken nextToken =
+                        currentToken.advancedTo(record.topic(), record.partition(), record.offset());
                 logger.debug("Advancing token from [{}] to [{}]", currentToken, nextToken);
 
                 currentToken = nextToken;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListener.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListener.java
@@ -76,7 +76,7 @@ public class TrackingTokenConsumerRebalanceListener<K, V> implements ConsumerReb
     public void onPartitionsAssigned(Collection<TopicPartition> assignedPartitions) {
         KafkaTrackingToken currentToken = tokenSupplier.get();
         assignedPartitions.forEach(assignedPartition -> {
-            Map<TopicPartition, Long> tokenPartitionPositions = currentToken.tokenPartitionPositions();
+            Map<TopicPartition, Long> tokenPartitionPositions = currentToken.positions();
 
             long offset = 0L;
             if (tokenPartitionPositions.containsKey(assignedPartition)) {

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListener.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListener.java
@@ -76,12 +76,11 @@ public class TrackingTokenConsumerRebalanceListener<K, V> implements ConsumerReb
     public void onPartitionsAssigned(Collection<TopicPartition> assignedPartitions) {
         KafkaTrackingToken currentToken = tokenSupplier.get();
         assignedPartitions.forEach(assignedPartition -> {
-            int partition = assignedPartition.partition();
-            Map<Integer, Long> tokenPartitionPositions = currentToken.partitionPositions();
+            Map<TopicPartition, Long> tokenPartitionPositions = currentToken.tokenPartitionPositions();
 
             long offset = 0L;
-            if (tokenPartitionPositions.containsKey(partition)) {
-                offset = tokenPartitionPositions.get(partition) + 1;
+            if (tokenPartitionPositions.containsKey(assignedPartition)) {
+                offset = tokenPartitionPositions.get(assignedPartition) + 1;
             }
             consumer.seek(assignedPartition, offset);
         });

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/KafkaIntegrationTest.java
@@ -41,6 +41,7 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.axonframework.eventhandling.GenericEventMessage.asEventMessage;
@@ -106,7 +107,7 @@ class KafkaIntegrationTest {
     void testPublishAndReadMessages() throws Exception {
         StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
                 StreamableKafkaMessageSource.<String, byte[]>builder()
-                        .topic("integration")
+                        .topics(Collections.singletonList("integration"))
                         .consumerFactory(consumerFactory)
                         .fetcher(fetcher)
                         .build();

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -153,13 +153,13 @@ class AsyncFetcherTest {
         SortedKafkaMessageBuffer<KafkaEventMessage> testBuffer =
                 new LatchedSortedKafkaMessageBuffer<>(expectedNumberOfMessages, messageCounter);
 
-        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
-        testTopicPartitionPositions.put(new TopicPartition(testTopic, 0), 5L);
-        testTopicPartitionPositions.put(new TopicPartition(testTopic, 1), 1L);
-        testTopicPartitionPositions.put(new TopicPartition(testTopic, 2), 9L);
-        testTopicPartitionPositions.put(new TopicPartition(testTopic, 3), 4L);
-        testTopicPartitionPositions.put(new TopicPartition(testTopic, 4), 0L);
-        KafkaTrackingToken testStartToken = KafkaTrackingToken.newInstance(testTopicPartitionPositions);
+        Map<TopicPartition, Long> testPositions = new HashMap<>();
+        testPositions.put(new TopicPartition(testTopic, 0), 5L);
+        testPositions.put(new TopicPartition(testTopic, 1), 1L);
+        testPositions.put(new TopicPartition(testTopic, 2), 9L);
+        testPositions.put(new TopicPartition(testTopic, 3), 4L);
+        testPositions.put(new TopicPartition(testTopic, 4), 0L);
+        KafkaTrackingToken testStartToken = KafkaTrackingToken.newInstance(testPositions);
 
         Consumer<String, String> testConsumer = consumerFactory(kafkaBroker).createConsumer(DEFAULT_GROUP_ID);
         testConsumer.subscribe(

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -153,13 +153,13 @@ class AsyncFetcherTest {
         SortedKafkaMessageBuffer<KafkaEventMessage> testBuffer =
                 new LatchedSortedKafkaMessageBuffer<>(expectedNumberOfMessages, messageCounter);
 
-        Map<Integer, Long> testPartitionPositions = new HashMap<>();
-        testPartitionPositions.put(0, 5L);
-        testPartitionPositions.put(1, 1L);
-        testPartitionPositions.put(2, 9L);
-        testPartitionPositions.put(3, 4L);
-        testPartitionPositions.put(4, 0L);
-        KafkaTrackingToken testStartToken = KafkaTrackingToken.newInstance(testPartitionPositions);
+        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
+        testTopicPartitionPositions.put(new TopicPartition(testTopic, 0), 5L);
+        testTopicPartitionPositions.put(new TopicPartition(testTopic, 1), 1L);
+        testTopicPartitionPositions.put(new TopicPartition(testTopic, 2), 9L);
+        testTopicPartitionPositions.put(new TopicPartition(testTopic, 3), 4L);
+        testTopicPartitionPositions.put(new TopicPartition(testTopic, 4), 0L);
+        KafkaTrackingToken testStartToken = KafkaTrackingToken.newInstance(testTopicPartitionPositions);
 
         Consumer<String, String> testConsumer = consumerFactory(kafkaBroker).createConsumer(DEFAULT_GROUP_ID);
         testConsumer.subscribe(

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/KafkaTrackingTokenTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/KafkaTrackingTokenTest.java
@@ -89,7 +89,7 @@ class KafkaTrackingTokenTest {
 
     @Test
     void testTokenIsHumanReadable() {
-        assertEquals("KafkaTrackingToken{partitionPositions={0=0}}", nonEmptyToken().toString());
+        assertEquals("KafkaTrackingToken{positions={topic-0=0}}", nonEmptyToken().toString());
     }
 
     private static KafkaTrackingToken nonEmptyToken() {
@@ -98,36 +98,36 @@ class KafkaTrackingTokenTest {
 
     @Test
     void testAdvanceToLaterTimestamp() {
-        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
-        testTopicPartitionPositions.put(TEST_TOPIC_PARTITION, 0L);
-        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 0L);
-        KafkaTrackingToken testToken = newInstance(testTopicPartitionPositions);
+        Map<TopicPartition, Long> testPositions = new HashMap<>();
+        testPositions.put(TEST_TOPIC_PARTITION, 0L);
+        testPositions.put(new TopicPartition(TEST_TOPIC, 1), 0L);
+        KafkaTrackingToken testToken = newInstance(testPositions);
 
         KafkaTrackingToken testSubject = testToken.advancedTo(TEST_TOPIC, TEST_PARTITION, 1L);
 
         assertNotSame(testSubject, testToken);
-        assertEquals(Long.valueOf(1), testSubject.tokenPartitionPositions().get(TEST_TOPIC_PARTITION));
+        assertEquals(Long.valueOf(1), testSubject.positions().get(TEST_TOPIC_PARTITION));
         assertKnownEventIds(testSubject, TEST_TOPIC_PARTITION, new TopicPartition(TEST_TOPIC, 1));
     }
 
     @Test
     void testAdvanceToOlderTimestamp() {
-        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
-        testTopicPartitionPositions.put(TEST_TOPIC_PARTITION, 1L);
-        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 0L);
-        KafkaTrackingToken testToken = newInstance(testTopicPartitionPositions);
+        Map<TopicPartition, Long> testPositions = new HashMap<>();
+        testPositions.put(TEST_TOPIC_PARTITION, 1L);
+        testPositions.put(new TopicPartition(TEST_TOPIC, 1), 0L);
+        KafkaTrackingToken testToken = newInstance(testPositions);
 
         KafkaTrackingToken testSubject = testToken.advancedTo(TEST_TOPIC, TEST_PARTITION, 0L);
 
         assertNotSame(testSubject, testToken);
-        assertEquals(Long.valueOf(0), testSubject.tokenPartitionPositions().get(TEST_TOPIC_PARTITION));
+        assertEquals(Long.valueOf(0), testSubject.positions().get(TEST_TOPIC_PARTITION));
         assertKnownEventIds(testSubject, TEST_TOPIC_PARTITION, new TopicPartition(TEST_TOPIC, 1));
     }
 
     private static void assertKnownEventIds(KafkaTrackingToken token, TopicPartition... expectedKnownIds) {
         assertEquals(
                 Stream.of(expectedKnownIds).collect(toSet()),
-                new HashSet<>(token.tokenPartitionPositions().keySet())
+                new HashSet<>(token.positions().keySet())
         );
     }
 
@@ -144,54 +144,54 @@ class KafkaTrackingTokenTest {
 
     @Test
     void testUpperBound() {
-        Map<TopicPartition, Long> firstTopicPartitionPositions = new HashMap<>();
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
-        KafkaTrackingToken first = newInstance(firstTopicPartitionPositions);
+        Map<TopicPartition, Long> firstPositions = new HashMap<>();
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
+        KafkaTrackingToken first = newInstance(firstPositions);
 
-        Map<TopicPartition, Long> secondTopicPartitionPositions = new HashMap<>();
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
-        KafkaTrackingToken second = newInstance(secondTopicPartitionPositions);
+        Map<TopicPartition, Long> secondPositions = new HashMap<>();
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
+        KafkaTrackingToken second = newInstance(secondPositions);
 
-        Map<TopicPartition, Long> expectedTopicPartitionPositions = new HashMap<>();
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
-        KafkaTrackingToken expected = newInstance(expectedTopicPartitionPositions);
+        Map<TopicPartition, Long> expectedPositions = new HashMap<>();
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
+        KafkaTrackingToken expected = newInstance(expectedPositions);
 
         assertEquals(expected, first.upperBound(second));
     }
 
     @Test
     void testLowerBound() {
-        Map<TopicPartition, Long> firstTopicPartitionPositions = new HashMap<>();
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
-        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
-        KafkaTrackingToken first = newInstance(firstTopicPartitionPositions);
+        Map<TopicPartition, Long> firstPositions = new HashMap<>();
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        firstPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
+        KafkaTrackingToken first = newInstance(firstPositions);
 
-        Map<TopicPartition, Long> secondTopicPartitionPositions = new HashMap<>();
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
-        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
-        KafkaTrackingToken second = newInstance(secondTopicPartitionPositions);
+        Map<TopicPartition, Long> secondPositions = new HashMap<>();
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        secondPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
+        KafkaTrackingToken second = newInstance(secondPositions);
 
-        Map<TopicPartition, Long> expectedTopicPartitionPositions = new HashMap<>();
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 0L);
-        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 0L);
-        KafkaTrackingToken expected = newInstance(expectedTopicPartitionPositions);
+        Map<TopicPartition, Long> expectedPositions = new HashMap<>();
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 3), 0L);
+        expectedPositions.put(new TopicPartition(TEST_TOPIC, 4), 0L);
+        KafkaTrackingToken expected = newInstance(expectedPositions);
 
         assertEquals(expected, first.lowerBound(second));
     }
@@ -208,23 +208,15 @@ class KafkaTrackingTokenTest {
     void testRelationOfCoversAndUpperBounds() {
         Random random = new Random();
         for (int i = 0; i <= 10; i++) {
-            Map<TopicPartition, Long> firstTopicPartitionPositions = new HashMap<>();
-            firstTopicPartitionPositions.put(
-                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
-            );
-            firstTopicPartitionPositions.put(
-                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
-            );
-            KafkaTrackingToken first = newInstance(firstTopicPartitionPositions);
+            Map<TopicPartition, Long> firstPositions = new HashMap<>();
+            firstPositions.put(new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1);
+            firstPositions.put(new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1);
+            KafkaTrackingToken first = newInstance(firstPositions);
 
-            Map<TopicPartition, Long> secondTopicPartitionPositions = new HashMap<>();
-            secondTopicPartitionPositions.put(
-                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
-            );
-            secondTopicPartitionPositions.put(
-                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
-            );
-            KafkaTrackingToken second = newInstance(secondTopicPartitionPositions);
+            Map<TopicPartition, Long> secondPositions = new HashMap<>();
+            secondPositions.put(new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1);
+            secondPositions.put(new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1);
+            KafkaTrackingToken second = newInstance(secondPositions);
 
             if (first.upperBound(second).equals(first)) {
                 assertTrue(first.covers(second),

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/KafkaTrackingTokenTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/KafkaTrackingTokenTest.java
@@ -17,230 +17,224 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer.streamable;
 
 import org.apache.kafka.common.TopicPartition;
-import org.assertj.core.util.Lists;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toSet;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotSame;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.extensions.kafka.eventhandling.consumer.streamable.KafkaTrackingToken.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the {@link KafkaTrackingToken}.
+ * Tests validating the {@link KafkaTrackingToken}.
  *
  * @author Nakul Mishra
  * @author Steven van Beelen
  */
-public class KafkaTrackingTokenTest {
+class KafkaTrackingTokenTest {
 
-    @SuppressWarnings("ConstantConditions")
-    @Test
-    public void testNullTokenShouldBeEmpty() {
-        assertThat(isEmpty(null)).isTrue();
-    }
+    private static final String TEST_TOPIC = "topic";
+    private static final int TEST_PARTITION = 0;
+    private static final TopicPartition TEST_TOPIC_PARTITION = new TopicPartition(TEST_TOPIC, TEST_PARTITION);
 
     @Test
-    public void testTokensWithoutPartitionsShouldBeEmpty() {
-        assertThat(isEmpty(emptyToken())).isTrue();
-    }
-
-    @Test
-    public void testTokensWithPartitionsShouldBeEmpty() {
-        assertThat(isNotEmpty(nonEmptyToken())).isTrue();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAdvanceToInvalidPartition() {
-        KafkaTrackingToken.newInstance(Collections.emptyMap()).advancedTo(-1, 1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAdvanceToInvalidOffset() {
-        KafkaTrackingToken.newInstance(Collections.emptyMap()).advancedTo(0, -1);
+    void testNullTokenShouldBeEmpty() {
+        //noinspection ConstantConditions
+        assertTrue(isEmpty(null));
     }
 
     @Test
-    public void testCompareTokens() {
+    void testTokensWithoutPartitionsShouldBeEmpty() {
+        assertTrue(isEmpty(emptyToken()));
+    }
+
+    @Test
+    void testTokensWithPartitionsShouldBeEmpty() {
+        assertTrue(isNotEmpty(nonEmptyToken()));
+    }
+
+    @Test
+    void testAdvanceToInvalidTopic() {
+        assertThrows(IllegalArgumentException.class, () -> emptyToken().advancedTo("", 0, 1));
+    }
+
+    @Test
+    void testAdvanceToInvalidPartition() {
+        assertThrows(IllegalArgumentException.class, () -> emptyToken().advancedTo(TEST_TOPIC, -1, 1));
+    }
+
+    @Test
+    void testAdvanceToInvalidOffset() {
+        assertThrows(IllegalArgumentException.class, () -> emptyToken().advancedTo(TEST_TOPIC, 0, -1));
+    }
+
+    @Test
+    void testCompareTokens() {
         KafkaTrackingToken original = nonEmptyToken();
-        KafkaTrackingToken copy = KafkaTrackingToken.newInstance(Collections.singletonMap(0, 0L));
-        KafkaTrackingToken forge = KafkaTrackingToken.newInstance(Collections.singletonMap(0, 1L));
+        KafkaTrackingToken copy = newInstance(singletonMap(TEST_TOPIC_PARTITION, 0L));
+        KafkaTrackingToken forge = newInstance(singletonMap(TEST_TOPIC_PARTITION, 1L));
 
-        assertThat(original).isEqualTo(original);
-        assertThat(copy).isEqualTo(original);
-        assertThat(copy.hashCode()).isEqualTo(original.hashCode());
-        assertThat(original).isNotEqualTo(forge);
-        assertThat(original.hashCode()).isNotEqualTo(forge.hashCode());
-        assertThat(original).isNotEqualTo("foo");
+        assertEquals(original, original);
+        assertEquals(original, copy);
+        assertEquals(original.hashCode(), copy.hashCode());
+        assertNotEquals(forge, original);
+        assertNotEquals(forge.hashCode(), original.hashCode());
+        assertNotEquals("foo", original);
     }
 
     @Test
-    public void testTokenIsHumanReadable() {
-        assertThat(nonEmptyToken().toString()).isEqualTo("KafkaTrackingToken{partitionPositions={0=0}}");
-    }
-
-    @Test
-    public void testAdvanceToLaterTimestamp() {
-        Map<Integer, Long> testPartitionPositions = new HashMap<>();
-        testPartitionPositions.put(0, 0L);
-        testPartitionPositions.put(1, 0L);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(testPartitionPositions);
-
-        KafkaTrackingToken testSubject = testToken.advancedTo(0, 1L);
-
-        assertNotSame(testSubject, testToken);
-        assertEquals(Long.valueOf(1), testSubject.partitionPositions().get(0));
-        assertKnownEventIds(testSubject, 0, 1);
-    }
-
-    @Test
-    public void testAdvanceToOlderTimestamp() {
-        Map<Integer, Long> testPartitionPositions = new HashMap<>();
-        testPartitionPositions.put(0, 1L);
-        testPartitionPositions.put(1, 0L);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(testPartitionPositions);
-
-        KafkaTrackingToken testSubject = testToken.advancedTo(0, 0L);
-
-        assertNotSame(testSubject, testToken);
-        assertEquals(Long.valueOf(0), testSubject.partitionPositions().get(0));
-        assertKnownEventIds(testSubject, 0, 1);
-    }
-
-    @Test
-    public void testTopicPartitionCreation() {
-        assertEquals(new TopicPartition("foo", 0), KafkaTrackingToken.partition("foo", 0));
-    }
-
-    @Test
-    public void testRestoringKafkaPartitionsFromExistingToken() {
-        Map<Integer, Long> testPartitionPositions = new HashMap<>();
-        testPartitionPositions.put(0, 0L);
-        testPartitionPositions.put(2, 10L);
-
-        KafkaTrackingToken existingToken = KafkaTrackingToken.newInstance(testPartitionPositions);
-
-        Collection<TopicPartition> expected =
-                Lists.newArrayList(new TopicPartition("bar", 0), new TopicPartition("bar", 2));
-        assertEquals(expected, existingToken.partitions("bar"));
-    }
-
-    @Test
-    public void testAdvancingATokenMakesItCoverThePrevious() {
-        KafkaTrackingToken testSubject = KafkaTrackingToken.newInstance(Collections.singletonMap(0, 0L));
-        KafkaTrackingToken advancedToken = testSubject.advancedTo(0, 1);
-        assertThat(advancedToken.covers(testSubject)).isTrue();
-        assertThat(KafkaTrackingToken.newInstance(Collections.singletonMap(1, 0L)).covers(testSubject)).isFalse();
-    }
-
-    @Test
-    public void testUpperBound() {
-        Map<Integer, Long> firstPartitionPositions = new HashMap<>();
-        firstPartitionPositions.put(0, 0L);
-        firstPartitionPositions.put(1, 10L);
-        firstPartitionPositions.put(2, 2L);
-        firstPartitionPositions.put(3, 2L);
-        KafkaTrackingToken first = KafkaTrackingToken.newInstance(firstPartitionPositions);
-
-        Map<Integer, Long> secondPartitionPositions = new HashMap<>();
-        secondPartitionPositions.put(0, 10L);
-        secondPartitionPositions.put(1, 1L);
-        secondPartitionPositions.put(2, 2L);
-        secondPartitionPositions.put(4, 3L);
-        KafkaTrackingToken second = KafkaTrackingToken.newInstance(secondPartitionPositions);
-
-        Map<Integer, Long> expectedPartitionPositions = new HashMap<>();
-        expectedPartitionPositions.put(0, 10L);
-        expectedPartitionPositions.put(1, 10L);
-        expectedPartitionPositions.put(2, 2L);
-        expectedPartitionPositions.put(3, 2L);
-        expectedPartitionPositions.put(4, 3L);
-        KafkaTrackingToken expected = KafkaTrackingToken.newInstance(expectedPartitionPositions);
-
-        assertThat(first.upperBound(second)).isEqualTo(expected);
-    }
-
-    @Test
-    public void testLowerBound() {
-        Map<Integer, Long> firstPartitionPositions = new HashMap<>();
-        firstPartitionPositions.put(0, 0L);
-        firstPartitionPositions.put(1, 10L);
-        firstPartitionPositions.put(2, 2L);
-        firstPartitionPositions.put(3, 2L);
-        KafkaTrackingToken first = KafkaTrackingToken.newInstance(firstPartitionPositions);
-
-        Map<Integer, Long> secondPartitionPositions = new HashMap<>();
-        secondPartitionPositions.put(0, 10L);
-        secondPartitionPositions.put(1, 1L);
-        secondPartitionPositions.put(2, 2L);
-        secondPartitionPositions.put(4, 3L);
-        KafkaTrackingToken second = KafkaTrackingToken.newInstance(secondPartitionPositions);
-
-        Map<Integer, Long> expectedPartitionPositions = new HashMap<>();
-        expectedPartitionPositions.put(0, 0L);
-        expectedPartitionPositions.put(1, 1L);
-        expectedPartitionPositions.put(2, 2L);
-        expectedPartitionPositions.put(3, 0L);
-        expectedPartitionPositions.put(4, 0L);
-        KafkaTrackingToken expected = KafkaTrackingToken.newInstance(expectedPartitionPositions);
-
-        assertThat(first.lowerBound(second)).isEqualTo(expected);
-    }
-
-    @Test
-    public void testCoversRegression() {
-        KafkaTrackingToken first = KafkaTrackingToken.newInstance(Collections.singletonMap(1, 2L));
-        KafkaTrackingToken second = KafkaTrackingToken.newInstance(Collections.singletonMap(0, 1L));
-
-        assertThat(first.covers(second)).isFalse();
-    }
-
-    @Test
-    public void testRelationOfCoversAndUpperBounds() {
-        Random random = new Random();
-        for (int i = 0; i <= 10; i++) {
-            Map<Integer, Long> firstPartitionPositions = new HashMap<>();
-            firstPartitionPositions.put(random.nextInt(2), (long) random.nextInt(4) + 1);
-            firstPartitionPositions.put(random.nextInt(2), (long) random.nextInt(4) + 1);
-            KafkaTrackingToken first = KafkaTrackingToken.newInstance(firstPartitionPositions);
-
-            Map<Integer, Long> secondPartitionPositions = new HashMap<>();
-            secondPartitionPositions.put(random.nextInt(2), (long) random.nextInt(4) + 1);
-            secondPartitionPositions.put(random.nextInt(2), (long) random.nextInt(4) + 1);
-            KafkaTrackingToken second = KafkaTrackingToken.newInstance(secondPartitionPositions);
-
-            if (first.upperBound(second).equals(first)) {
-                assertThat(first.covers(second))
-                        .withFailMessage(
-                                "The upper bound of first(%s) and second(%s) is not first, so first shouldn't cover second",
-                                first,
-                                second)
-                        .isTrue();
-            } else {
-                assertThat(first.covers(second))
-                        .withFailMessage(
-                                "The upper bound of first(%s) and second(%s) is not first, so first shouldn't cover second",
-                                first,
-                                second)
-                        .isFalse();
-            }
-        }
+    void testTokenIsHumanReadable() {
+        assertEquals("KafkaTrackingToken{partitionPositions={0=0}}", nonEmptyToken().toString());
     }
 
     private static KafkaTrackingToken nonEmptyToken() {
-        return KafkaTrackingToken.newInstance(Collections.singletonMap(0, 0L));
+        return newInstance(singletonMap(TEST_TOPIC_PARTITION, 0L));
     }
 
-    private static void assertKnownEventIds(KafkaTrackingToken token, Integer... expectedKnownIds) {
-        assertEquals(Stream.of(expectedKnownIds).collect(toSet()),
-                     new HashSet<>(token.partitionPositions().keySet()));
+    @Test
+    void testAdvanceToLaterTimestamp() {
+        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
+        testTopicPartitionPositions.put(TEST_TOPIC_PARTITION, 0L);
+        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 0L);
+        KafkaTrackingToken testToken = newInstance(testTopicPartitionPositions);
+
+        KafkaTrackingToken testSubject = testToken.advancedTo(TEST_TOPIC, TEST_PARTITION, 1L);
+
+        assertNotSame(testSubject, testToken);
+        assertEquals(Long.valueOf(1), testSubject.tokenPartitionPositions().get(TEST_TOPIC_PARTITION));
+        assertKnownEventIds(testSubject, TEST_TOPIC_PARTITION, new TopicPartition(TEST_TOPIC, 1));
+    }
+
+    @Test
+    void testAdvanceToOlderTimestamp() {
+        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
+        testTopicPartitionPositions.put(TEST_TOPIC_PARTITION, 1L);
+        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 0L);
+        KafkaTrackingToken testToken = newInstance(testTopicPartitionPositions);
+
+        KafkaTrackingToken testSubject = testToken.advancedTo(TEST_TOPIC, TEST_PARTITION, 0L);
+
+        assertNotSame(testSubject, testToken);
+        assertEquals(Long.valueOf(0), testSubject.tokenPartitionPositions().get(TEST_TOPIC_PARTITION));
+        assertKnownEventIds(testSubject, TEST_TOPIC_PARTITION, new TopicPartition(TEST_TOPIC, 1));
+    }
+
+    private static void assertKnownEventIds(KafkaTrackingToken token, TopicPartition... expectedKnownIds) {
+        assertEquals(
+                Stream.of(expectedKnownIds).collect(toSet()),
+                new HashSet<>(token.tokenPartitionPositions().keySet())
+        );
+    }
+
+    @Test
+    void testAdvancingATokenMakesItCoverThePrevious() {
+        KafkaTrackingToken testSubject = newInstance(singletonMap(TEST_TOPIC_PARTITION, 0L));
+        KafkaTrackingToken advancedToken = testSubject.advancedTo(TEST_TOPIC, TEST_PARTITION, 1);
+        KafkaTrackingToken uncoveredToken =
+                newInstance(singletonMap(new TopicPartition(TEST_TOPIC, 1), 0L));
+
+        assertTrue(advancedToken.covers(testSubject));
+        assertFalse(uncoveredToken.covers(testSubject));
+    }
+
+    @Test
+    void testUpperBound() {
+        Map<TopicPartition, Long> firstTopicPartitionPositions = new HashMap<>();
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
+        KafkaTrackingToken first = newInstance(firstTopicPartitionPositions);
+
+        Map<TopicPartition, Long> secondTopicPartitionPositions = new HashMap<>();
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
+        KafkaTrackingToken second = newInstance(secondTopicPartitionPositions);
+
+        Map<TopicPartition, Long> expectedTopicPartitionPositions = new HashMap<>();
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
+        KafkaTrackingToken expected = newInstance(expectedTopicPartitionPositions);
+
+        assertEquals(expected, first.upperBound(second));
+    }
+
+    @Test
+    void testLowerBound() {
+        Map<TopicPartition, Long> firstTopicPartitionPositions = new HashMap<>();
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 10L);
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        firstTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 2L);
+        KafkaTrackingToken first = newInstance(firstTopicPartitionPositions);
+
+        Map<TopicPartition, Long> secondTopicPartitionPositions = new HashMap<>();
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 10L);
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        secondTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 3L);
+        KafkaTrackingToken second = newInstance(secondTopicPartitionPositions);
+
+        Map<TopicPartition, Long> expectedTopicPartitionPositions = new HashMap<>();
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), 0L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), 1L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), 2L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 3), 0L);
+        expectedTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 4), 0L);
+        KafkaTrackingToken expected = newInstance(expectedTopicPartitionPositions);
+
+        assertEquals(expected, first.lowerBound(second));
+    }
+
+    @Test
+    void testCoversRegression() {
+        KafkaTrackingToken first = newInstance(singletonMap(new TopicPartition(TEST_TOPIC, 1), 2L));
+        KafkaTrackingToken second = newInstance(singletonMap(new TopicPartition(TEST_TOPIC, 0), 1L));
+
+        assertFalse(first.covers(second));
+    }
+
+    @Test
+    void testRelationOfCoversAndUpperBounds() {
+        Random random = new Random();
+        for (int i = 0; i <= 10; i++) {
+            Map<TopicPartition, Long> firstTopicPartitionPositions = new HashMap<>();
+            firstTopicPartitionPositions.put(
+                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
+            );
+            firstTopicPartitionPositions.put(
+                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
+            );
+            KafkaTrackingToken first = newInstance(firstTopicPartitionPositions);
+
+            Map<TopicPartition, Long> secondTopicPartitionPositions = new HashMap<>();
+            secondTopicPartitionPositions.put(
+                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
+            );
+            secondTopicPartitionPositions.put(
+                    new TopicPartition(TEST_TOPIC, random.nextInt(2)), (long) random.nextInt(4) + 1
+            );
+            KafkaTrackingToken second = newInstance(secondTopicPartitionPositions);
+
+            if (first.upperBound(second).equals(first)) {
+                assertTrue(first.covers(second),
+                           "The upper bound of first[" + first + "] and second[" + second
+                                   + "] is not first, so first shouldn't cover second");
+            } else {
+                assertFalse(first.covers(second),
+                            "The upper bound of first[" + first + "] and second[" + second
+                                    + "] is not first, so first shouldn't cover second");
+            }
+        }
     }
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSourceTest.java
@@ -68,8 +68,13 @@ class StreamableKafkaMessageSourceTest {
     }
 
     @Test
-    void testBuildingWithInvalidTopicShouldThrowAxonConfigurationException() {
-        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().topic(null));
+    void testBuildingWithInvalidTopicsShouldThrowAxonConfigurationException() {
+        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().topics(null));
+    }
+
+    @Test
+    void testBuildWithInvalidTopicThrowsAxonConfigurationException() {
+        assertThrows(AxonConfigurationException.class, () -> StreamableKafkaMessageSource.builder().addTopic(null));
     }
 
     @Test

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingRecordConverterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingRecordConverterTest.java
@@ -43,6 +43,7 @@ class TrackingRecordConverterTest {
 
     private static final String TEST_TOPIC = "some-topic";
     private static final int TEST_PARTITION = 0;
+    private static final TopicPartition TEST_TOPIC_PARTITION = new TopicPartition(TEST_TOPIC, TEST_PARTITION);
 
     private KafkaMessageConverter<String, String> messageConverter;
 
@@ -74,7 +75,7 @@ class TrackingRecordConverterTest {
         int expectedNumberOfRecords = 42;
         long expectedOffset = expectedNumberOfRecords - 1;
         KafkaTrackingToken expectedCurrentToken =
-                KafkaTrackingToken.newInstance(Collections.singletonMap(TEST_PARTITION, expectedOffset));
+                KafkaTrackingToken.newInstance(Collections.singletonMap(TEST_TOPIC_PARTITION, expectedOffset));
 
         ConsumerRecords<String, String> testRecords = buildConsumerRecords(expectedNumberOfRecords);
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerIntegrationTest.java
@@ -122,13 +122,13 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
                 producerFactory.createProducer(), topic, recordsPerPartitions, kafkaBroker.getPartitionsPerTopic()
         );
 
-        Map<TopicPartition, Long> topicPartitionPositions = new HashMap<>();
-        topicPartitionPositions.put(new TopicPartition(topic, 0), 5L);
-        topicPartitionPositions.put(new TopicPartition(topic, 1), 1L);
-        topicPartitionPositions.put(new TopicPartition(topic, 2), 9L);
-        topicPartitionPositions.put(new TopicPartition(topic, 3), 4L);
-        topicPartitionPositions.put(new TopicPartition(topic, 4), 0L);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(topicPartitionPositions);
+        Map<TopicPartition, Long> positions = new HashMap<>();
+        positions.put(new TopicPartition(topic, 0), 5L);
+        positions.put(new TopicPartition(topic, 1), 1L);
+        positions.put(new TopicPartition(topic, 2), 9L);
+        positions.put(new TopicPartition(topic, 3), 4L);
+        positions.put(new TopicPartition(topic, 4), 0L);
+        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(positions);
         // This number corresponds to the steps the five partition's
         //  their offsets will increase given the published number of `recordsPerPartitions`
         int numberOfRecordsToConsume = 26;
@@ -143,7 +143,7 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
                 pollUntilAtLeastNumRecords((KafkaConsumer<byte[], byte[]>) testConsumer, numberOfRecordsToConsume);
         resultRecords.foreach(resultRecord -> {
             TopicPartition resultTopicPartition = new TopicPartition(resultRecord.topic(), resultRecord.partition());
-            assertTrue(resultRecord.offset() > topicPartitionPositions.get(resultTopicPartition));
+            assertTrue(resultRecord.offset() > positions.get(resultTopicPartition));
             // This ugly stuff is needed since I have to deal with a scala.collection.Seq
             return null;
         });
@@ -161,13 +161,13 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
                 testProducer, topic, recordsPerPartitions, kafkaBroker.getPartitionsPerTopic()
         );
 
-        Map<TopicPartition, Long> topicPartitionPositions = new HashMap<>();
-        topicPartitionPositions.put(new TopicPartition(topic, 0), 5L);
-        topicPartitionPositions.put(new TopicPartition(topic, 1), 1L);
-        topicPartitionPositions.put(new TopicPartition(topic, 2), 9L);
-        topicPartitionPositions.put(new TopicPartition(topic, 3), 4L);
-        topicPartitionPositions.put(new TopicPartition(topic, 4), 0L);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(topicPartitionPositions);
+        Map<TopicPartition, Long> positions = new HashMap<>();
+        positions.put(new TopicPartition(topic, 0), 5L);
+        positions.put(new TopicPartition(topic, 1), 1L);
+        positions.put(new TopicPartition(topic, 2), 9L);
+        positions.put(new TopicPartition(topic, 3), 4L);
+        positions.put(new TopicPartition(topic, 4), 0L);
+        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(positions);
         // This number corresponds to the steps the five partition's
         //  their offsets will increase given the published number of `recordsPerPartitions`
         int numberOfRecordsToConsume = 26;
@@ -183,7 +183,7 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
                 pollUntilAtLeastNumRecords((KafkaConsumer<byte[], byte[]>) testConsumer, numberOfRecordsToConsume);
         resultRecords.foreach(resultRecord -> {
             TopicPartition resultTopicPartition = new TopicPartition(resultRecord.topic(), resultRecord.partition());
-            assertTrue(resultRecord.offset() > topicPartitionPositions.get(resultTopicPartition));
+            assertTrue(resultRecord.offset() > positions.get(resultTopicPartition));
             // This ugly stuff is needed since I have to deal with a scala.collection.Seq
             return null;
         });

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
 import org.junit.jupiter.api.*;
@@ -41,10 +42,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyMap;
 import static kafka.utils.TestUtils.pollUntilAtLeastNumRecords;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.consumerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.kafka.test.utils.KafkaTestUtils.getRecords;
 
 /***
@@ -58,7 +59,6 @@ import static org.springframework.kafka.test.utils.KafkaTestUtils.getRecords;
 @DirtiesContext
 @EmbeddedKafka(
         topics = {
-                "testSeekUsing_NullToken_ConsumerStartsAtPositionZero",
                 "testSeekUsing_EmptyToken_ConsumerStartsAtPositionZero",
                 "testSeekUsing_ExistingToken_ConsumerStartsAtSpecificPosition",
                 "testSeekUsing_ExistingToken_ConsumerStartsAtSpecificPosition_AndCanContinueReadingNewRecords"
@@ -105,10 +105,10 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
         );
 
         getRecords(testConsumer).forEach(record -> {
-            assertThat(record.offset()).isZero();
+            assertEquals(0, record.offset());
             recordCounter.getAndIncrement();
         });
-        assertThat(recordCounter.get()).isEqualTo(expectedRecordCount);
+        assertEquals(expectedRecordCount, recordCounter.get());
 
         testConsumer.close();
     }
@@ -122,13 +122,13 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
                 producerFactory.createProducer(), topic, recordsPerPartitions, kafkaBroker.getPartitionsPerTopic()
         );
 
-        Map<Integer, Long> partitionPositions = new HashMap<>();
-        partitionPositions.put(0, 5L);
-        partitionPositions.put(1, 1L);
-        partitionPositions.put(2, 9L);
-        partitionPositions.put(3, 4L);
-        partitionPositions.put(4, 0L);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(partitionPositions);
+        Map<TopicPartition, Long> topicPartitionPositions = new HashMap<>();
+        topicPartitionPositions.put(new TopicPartition(topic, 0), 5L);
+        topicPartitionPositions.put(new TopicPartition(topic, 1), 1L);
+        topicPartitionPositions.put(new TopicPartition(topic, 2), 9L);
+        topicPartitionPositions.put(new TopicPartition(topic, 3), 4L);
+        topicPartitionPositions.put(new TopicPartition(topic, 4), 0L);
+        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(topicPartitionPositions);
         // This number corresponds to the steps the five partition's
         //  their offsets will increase given the published number of `recordsPerPartitions`
         int numberOfRecordsToConsume = 26;
@@ -141,9 +141,13 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
 
         Seq<ConsumerRecord<byte[], byte[]>> resultRecords =
                 pollUntilAtLeastNumRecords((KafkaConsumer<byte[], byte[]>) testConsumer, numberOfRecordsToConsume);
-        resultRecords.foreach(resultRecord -> assertThat(resultRecord.offset())
-                .isGreaterThan(partitionPositions.get(resultRecord.partition())));
-        assertThat(resultRecords.count(COUNT_ALL)).isEqualTo(numberOfRecordsToConsume);
+        resultRecords.foreach(resultRecord -> {
+            TopicPartition resultTopicPartition = new TopicPartition(resultRecord.topic(), resultRecord.partition());
+            assertTrue(resultRecord.offset() > topicPartitionPositions.get(resultTopicPartition));
+            // This ugly stuff is needed since I have to deal with a scala.collection.Seq
+            return null;
+        });
+        assertEquals(numberOfRecordsToConsume, resultRecords.count(COUNT_ALL));
 
         testConsumer.close();
     }
@@ -157,13 +161,13 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
                 testProducer, topic, recordsPerPartitions, kafkaBroker.getPartitionsPerTopic()
         );
 
-        Map<Integer, Long> partitionPositions = new HashMap<>();
-        partitionPositions.put(0, 5L);
-        partitionPositions.put(1, 1L);
-        partitionPositions.put(2, 9L);
-        partitionPositions.put(3, 4L);
-        partitionPositions.put(4, 0L);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(partitionPositions);
+        Map<TopicPartition, Long> topicPartitionPositions = new HashMap<>();
+        topicPartitionPositions.put(new TopicPartition(topic, 0), 5L);
+        topicPartitionPositions.put(new TopicPartition(topic, 1), 1L);
+        topicPartitionPositions.put(new TopicPartition(topic, 2), 9L);
+        topicPartitionPositions.put(new TopicPartition(topic, 3), 4L);
+        topicPartitionPositions.put(new TopicPartition(topic, 4), 0L);
+        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(topicPartitionPositions);
         // This number corresponds to the steps the five partition's
         //  their offsets will increase given the published number of `recordsPerPartitions`
         int numberOfRecordsToConsume = 26;
@@ -177,17 +181,25 @@ class TrackingTokenConsumerRebalanceListenerIntegrationTest {
         //noinspection unchecked
         Seq<ConsumerRecord<byte[], byte[]>> resultRecords =
                 pollUntilAtLeastNumRecords((KafkaConsumer<byte[], byte[]>) testConsumer, numberOfRecordsToConsume);
-        resultRecords.foreach(resultRecord -> assertThat(resultRecord.offset())
-                .isGreaterThan(partitionPositions.get(resultRecord.partition())));
-        assertThat(resultRecords.count(COUNT_ALL)).isEqualTo(numberOfRecordsToConsume);
+        resultRecords.foreach(resultRecord -> {
+            TopicPartition resultTopicPartition = new TopicPartition(resultRecord.topic(), resultRecord.partition());
+            assertTrue(resultRecord.offset() > topicPartitionPositions.get(resultTopicPartition));
+            // This ugly stuff is needed since I have to deal with a scala.collection.Seq
+            return null;
+        });
+        assertEquals(numberOfRecordsToConsume, resultRecords.count(COUNT_ALL));
 
         publishNewRecords(testProducer, topic);
         int secondNumberOfRecords = 4; // The `publishNewRecords(Producer, String)` produces 4 new records
         //noinspection unchecked
         resultRecords = pollUntilAtLeastNumRecords((KafkaConsumer<byte[], byte[]>) testConsumer, secondNumberOfRecords);
 
-        resultRecords.foreach(resultRecord -> assertThat(resultRecord.offset()).isEqualTo(10));
-        assertThat(resultRecords.count(COUNT_ALL)).isEqualTo(secondNumberOfRecords);
+        resultRecords.foreach(resultRecord -> {
+            assertEquals(10, resultRecord.offset());
+            // This ugly stuff is needed since I have to deal with a scala.collection.Seq
+            return null;
+        });
+        assertEquals(secondNumberOfRecords, resultRecords.count(COUNT_ALL));
 
         testConsumer.close();
     }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerTest.java
@@ -43,11 +43,11 @@ class TrackingTokenConsumerRebalanceListenerTest {
         long testOffsetForPartitionOne = 10L;
         long testOffsetForPartitionTwo = 15L;
 
-        Map<Integer, Long> testPartitionPositions = new HashMap<>();
-        testPartitionPositions.put(0, testOffsetForPartitionZero);
-        testPartitionPositions.put(1, testOffsetForPartitionOne);
-        testPartitionPositions.put(2, testOffsetForPartitionTwo);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(testPartitionPositions);
+        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
+        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), testOffsetForPartitionZero);
+        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), testOffsetForPartitionOne);
+        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), testOffsetForPartitionTwo);
+        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(testTopicPartitionPositions);
 
         TopicPartition testPartitionZero = new TopicPartition(TEST_TOPIC, 0);
         TopicPartition testPartitionOne = new TopicPartition(TEST_TOPIC, 1);

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListenerTest.java
@@ -43,11 +43,11 @@ class TrackingTokenConsumerRebalanceListenerTest {
         long testOffsetForPartitionOne = 10L;
         long testOffsetForPartitionTwo = 15L;
 
-        Map<TopicPartition, Long> testTopicPartitionPositions = new HashMap<>();
-        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 0), testOffsetForPartitionZero);
-        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 1), testOffsetForPartitionOne);
-        testTopicPartitionPositions.put(new TopicPartition(TEST_TOPIC, 2), testOffsetForPartitionTwo);
-        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(testTopicPartitionPositions);
+        Map<TopicPartition, Long> testPositions = new HashMap<>();
+        testPositions.put(new TopicPartition(TEST_TOPIC, 0), testOffsetForPartitionZero);
+        testPositions.put(new TopicPartition(TEST_TOPIC, 1), testOffsetForPartitionOne);
+        testPositions.put(new TopicPartition(TEST_TOPIC, 2), testOffsetForPartitionTwo);
+        KafkaTrackingToken testToken = KafkaTrackingToken.newInstance(testPositions);
 
         TopicPartition testPartitionZero = new TopicPartition(TEST_TOPIC, 0);
         TopicPartition testPartitionOne = new TopicPartition(TEST_TOPIC, 1);


### PR DESCRIPTION
The `KafkaTrackingToken` maintained a Map of `Integer` to `Long`, where the key specified the partition and the value that partitions offset. However, Kafka's` Consumer` API allows for subscribing to several topics at once, where the broker will decide which partitions of a given topic said `Consumer` would receive.

To allow for this flexibility in contacting to several topic-partition pairs (which currently is provided in the `SubscribableKafkaMessageSource`), the `KafkaTrackingToken` should store (Kafka's) `TopicPartition` as the keys instead of just the partition.

That's exactly what this PR brings us, with the added feature that several topics can be configured on a given `StreamableKafkaMessageSource`.

This pull request resolves issue #28.