### PR TITLE
Remove spring core overrides and upgrade Spring Boot to 2.4.1

### DIFF
--- a/kafka-axon-example/pom.xml
+++ b/kafka-axon-example/pom.xml
@@ -69,24 +69,6 @@
             <artifactId>spring-kafka</artifactId>
             <version>${spring-kafka.version}</version>
         </dependency>
-        <!-- Temporary dependency override from spring-kafka; required to coop with the fact spring-kafka isn't on 5.3.x yet -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <!-- Temporary dependency override from spring-kafka; required to coop with the fact spring-kafka isn't on 5.3.x yet -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-messaging</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <!-- Temporary dependency override from spring-kafka; required to coop with the fact spring-kafka isn't on 5.3.x yet -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -76,7 +76,6 @@
             <version>${spring-kafka-test.version}</version>
             <scope>test</scope>
         </dependency>
-
         <!--Required by spring kafka test-->
         <dependency>
             <groupId>org.assertj</groupId>
@@ -87,13 +86,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,7 @@
         <axon.version>4.0.4</axon.version>
         <kafka.version>2.6.0</kafka.version>
         <!-- Spring -->
-        <spring.version>5.3.2</spring.version>
-        <spring.boot.version>2.4.0</spring.boot.version>
+        <spring.boot.version>2.4.1</spring.boot.version>
         <!-- Logging -->
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.14.0</log4j.version>
@@ -69,13 +68,6 @@
 
     <dependencies>
         <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <version>${spring.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>


### PR DESCRIPTION
Bump of Spring core to `5.3.2` while Spring Boot was on `2.4.0` broke the build.

Either downgrading Spring core to `5.3.1` or upgrading to Spring Boot `2.4.1` would have just fixed the build.

The main issue was in Spring test, as one of the methods has been removed in `5.3.2`. The reason for Spring core overrides over Spring Boot, was because Spring Kafka Test used older `5.2.x` of Spring test.

It seems that this is not an issue anymore, and as such Spring core overrides have been removed