### PR TITLE
[#114] Removed spring-kafka-test from project and fixed tests

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -31,7 +31,6 @@
     </description>
 
     <properties>
-        <spring-kafka-test.version>2.6.5</spring-kafka-test.version>
         <jmh-core.version>1.27</jmh-core.version>
         <test-containers.version>1.15.2</test-containers.version>
     </properties>
@@ -67,13 +66,6 @@
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh-core.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.kafka</groupId>
-            <artifactId>spring-kafka-test</artifactId>
-            <version>${spring-kafka-test.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactoryTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactoryTest.java
@@ -24,12 +24,12 @@ import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
 import org.axonframework.extensions.kafka.eventhandling.util.KafkaAdminUtils;
 import org.axonframework.extensions.kafka.eventhandling.util.KafkaContainerTest;
 import org.junit.jupiter.api.*;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import java.util.Collections;
 
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.minimal;
+import static org.axonframework.extensions.kafka.eventhandling.util.KafkaTestUtils.getRecords;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -87,6 +87,6 @@ class DefaultConsumerFactoryTest extends KafkaContainerTest {
         testConsumer = testSubject.createConsumer(DEFAULT_GROUP_ID);
         testConsumer.subscribe(Collections.singleton(testTopic));
 
-        assertEquals(1, KafkaTestUtils.getRecords(testConsumer).count());
+        assertEquals(1, getRecords(testConsumer).count());
     }
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherTest.java
@@ -41,7 +41,6 @@ import org.axonframework.messaging.unitofwork.UnitOfWork;
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.junit.jupiter.api.*;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +55,7 @@ import static java.util.Collections.singletonList;
 import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.transactionalConsumerFactory;
+import static org.axonframework.extensions.kafka.eventhandling.util.KafkaTestUtils.getRecords;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.ackProducerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.transactionalProducerFactory;
 import static org.junit.jupiter.api.Assertions.*;
@@ -175,7 +175,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
 
         eventBus.publish(testMessages);
 
-        ConsumerRecords<?, ?> consumedRecords = KafkaTestUtils.getRecords(testConsumer, 60000, numberOfMessages);
+        ConsumerRecords<?, ?> consumedRecords = getRecords(testConsumer, 60000, numberOfMessages);
         assertEquals(numberOfMessages, consumedRecords.count());
         assertEquals(testMessages, monitor.getReceived());
         assertEquals(0, monitor.failureCount());
@@ -223,7 +223,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
         assertEquals(testMessages.size(), monitor.successCount());
         assertEquals(0, monitor.failureCount());
         assertEquals(0, monitor.ignoreCount());
-        assertEquals(testMessages.size(), KafkaTestUtils.getRecords(testConsumer).count());
+        assertEquals(testMessages.size(), getRecords(testConsumer).count());
     }
 
     @Test
@@ -242,7 +242,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
         assertEquals(1, monitor.successCount());
         assertEquals(0, monitor.failureCount());
         assertEquals(0, monitor.ignoreCount());
-        assertEquals(1, KafkaTestUtils.getRecords(testConsumer).count());
+        assertEquals(1, getRecords(testConsumer).count());
     }
 
     @Test
@@ -263,7 +263,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
         eventBus.publish(testMessage);
         uow.commit();
 
-        assertEquals(1, KafkaTestUtils.getRecords(testConsumer).count());
+        assertEquals(1, getRecords(testConsumer).count());
     }
 
     @Test
@@ -291,7 +291,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
             assertEquals(expectedException, e.getMessage());
         }
 
-        assertTrue(KafkaTestUtils.getRecords(testConsumer, 100).isEmpty(), "Didn't expect any consumer records");
+        assertTrue(getRecords(testConsumer, 100).isEmpty(), "Didn't expect any consumer records");
     }
 
     @Test
@@ -339,7 +339,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
         }
 
         testConsumer = buildConsumer(testTopic);
-        assertTrue(KafkaTestUtils.getRecords(testConsumer, 100).isEmpty(), "Didn't expect any consumer records");
+        assertTrue(getRecords(testConsumer, 100).isEmpty(), "Didn't expect any consumer records");
     }
 
     private KafkaPublisher<String, byte[]> buildPublisher(String topic) {
@@ -391,7 +391,7 @@ class KafkaPublisherTest extends KafkaContainerTest {
             uow.commit();
         } finally {
             testConsumer = buildConsumer(topic);
-            assertTrue(KafkaTestUtils.getRecords(testConsumer, 100).isEmpty(), "Didn't expect any consumer records");
+            assertTrue(getRecords(testConsumer, 100).isEmpty(), "Didn't expect any consumer records");
         }
     }
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/KafkaContainerCluster.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/KafkaContainerCluster.java
@@ -102,7 +102,7 @@ public class KafkaContainerCluster implements Startable {
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             e.printStackTrace();
         }
-        Unreliables.retryUntilTrue(30, TimeUnit.SECONDS, () -> {
+        Unreliables.retryUntilTrue(60, TimeUnit.SECONDS, () -> {
             Container.ExecResult result = this.zookeeper.execInContainer(
                     "sh", "-c",
                     "zookeeper-shell zookeeper:" + KafkaContainer.ZOOKEEPER_PORT + " ls /brokers/ids | tail -n 1"

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/KafkaTestUtils.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/KafkaTestUtils.java
@@ -1,0 +1,165 @@
+package org.axonframework.extensions.kafka.eventhandling.util;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Kafka testing utilities. Copied what was needed either from spring-kafka or kafka. Original authors are kept.
+ *
+ * @author Gary Russell
+ * @author Hugo Wood
+ * @author Artem Bilan
+ */
+public class KafkaTestUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaTestUtils.class);
+
+    /**
+     * Poll the consumer for records.
+     *
+     * @param consumer the consumer.
+     * @param <K>      the key type.
+     * @param <V>      the value type.
+     * @return the records.
+     * @see #getRecords(Consumer, long)
+     */
+    public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer) {
+        return getRecords(consumer, 60000);
+    }
+
+    /**
+     * Poll the consumer for records.
+     *
+     * @param consumer the consumer.
+     * @param timeout  max time in milliseconds to wait for records; forwarded to {@link Consumer#poll(long)}.
+     * @param <K>      the key type.
+     * @param <V>      the value type.
+     * @return the records.
+     * @throws IllegalStateException if the poll returns null (since 2.3.4).
+     * @since 2.0
+     */
+    public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer, long timeout) {
+        return getRecords(consumer, timeout, -1);
+    }
+
+    /**
+     * Poll the consumer for records.
+     *
+     * @param consumer   the consumer.
+     * @param timeout    max time in milliseconds to wait for records; forwarded to {@link Consumer#poll(long)}.
+     * @param <K>        the key type.
+     * @param <V>        the value type.
+     * @param minRecords wait until the timeout or at least this number of receords are received.
+     * @return the records.
+     * @throws IllegalStateException if the poll returns null.
+     * @since 2.4.2
+     */
+    public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer, long timeout, int minRecords) {
+        logger.debug("Polling...");
+        Map<TopicPartition, List<ConsumerRecord<K, V>>> records = new HashMap<>();
+        long remaining = timeout;
+        int count = 0;
+        do {
+            long t1 = System.currentTimeMillis();
+            ConsumerRecords<K, V> received = consumer.poll(Duration.ofMillis(remaining));
+            logger.debug("Received: " + received.count() + ", "
+                                 + received.partitions().stream()
+                                           .flatMap(p -> received.records(p).stream())
+                                           // map to same format as send metadata toString()
+                                           .map(r -> r.topic() + "-" + r.partition() + "@" + r.offset())
+                                           .collect(Collectors.toList()));
+            if (received == null) {
+                throw new IllegalStateException("null received from consumer.poll()");
+            }
+            if (minRecords < 0) {
+                return received;
+            } else {
+                count += received.count();
+                received.partitions().forEach(tp -> {
+                    List<ConsumerRecord<K, V>> recs = records.computeIfAbsent(tp, part -> new ArrayList<>());
+                    recs.addAll(received.records(tp));
+                });
+                remaining -= System.currentTimeMillis() - t1;
+            }
+        }
+        while (count < minRecords && remaining > 0);
+        return new ConsumerRecords<>(records);
+    }
+
+    /**
+     * Keep pooling from the {@code consumer} until we have at least the {@code numRecords} and return the records.
+     *
+     * @param consumer   the consumer
+     * @param numRecords number of records wanted
+     * @param waitTimeMs max wait time in milliseconds
+     * @param <K>        key of the record
+     * @param <V>        value of the record
+     * @return list of records pulled from the consumer
+     */
+    public static <K, V> List<ConsumerRecord<K, V>> pollUntilAtLeastNumRecords(
+            Consumer<K, V> consumer,
+            int numRecords,
+            long waitTimeMs) {
+        ArrayList<ConsumerRecord<K, V>> records = new ArrayList<>();
+        Predicate<ConsumerRecords<K, V>> pollAction = cr -> {
+            cr.forEach(records::add);
+            return records.size() >= numRecords;
+        };
+        pollRecordsUntilTrue(consumer,
+                             pollAction,
+                             waitTimeMs,
+                             String.format("Consumed %s records before timeout instead of the expected %s records",
+                                           records.size(),
+                                           numRecords)
+        );
+        return records;
+    }
+
+    private static <K, V> void pollRecordsUntilTrue(Consumer<K, V> consumer,
+                                                    Predicate<ConsumerRecords<K, V>> pollAction,
+                                                    long waitTimeMs, String msg) {
+        waitUntilTrue(() -> {
+            ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(100));
+            return pollAction.test(records);
+        }, msg, waitTimeMs, 100L);
+    }
+
+    /**
+     * Wait until the given condition is true or throw an exception if the given wait time elapses.
+     *
+     * @param condition  condition to check
+     * @param msg        error message
+     * @param waitTimeMs maximum time to wait and retest the condition before failing the test
+     * @param pause      delay between condition checks
+     */
+    private static void waitUntilTrue(Supplier<Boolean> condition, String msg, long waitTimeMs, long pause) {
+        long startTime = System.currentTimeMillis();
+        while (true) {
+            if (condition.get()) {
+                return;
+            }
+            if (System.currentTimeMillis() > startTime + waitTimeMs) {
+                Assertions.fail(msg);
+            }
+            try {
+                Thread.sleep(Long.min(waitTimeMs, pause));
+            } catch (InterruptedException ex) {
+                Assertions.fail("Interrupted by sleeping");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes #114.

The `spring-kafka-test` is removed in favor of copying just what was needed from that.
Also, 3 methods were in Scala from `kafka` repo itself and we rewritten them in Java.