### PR TITLE
chore: fix the build problems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,26 +42,20 @@ jobs:
 
       - name: Regular build
         run: |
-          mvn -B -U clean verify
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ./mvnw -B -U clean verify
 
       - name: Sonar analysis
         if: matrix.sonar-enabled
         run: | # no clean
-          mvn -B sonar:sonar \
+          ./mvnw -B sonar:sonar \
           -Dsonar.projectKey=AxonFramework_extension-kafka \
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \
           -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run integration tests
         run: | # no clean
-          mvn -B -Pitest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ./mvnw -B -Pitest
 
       - name: Deploy to Sonatype
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,12 +40,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven
 
-      - name: Maven operation with Sonar
-        if: matrix.sonar-enabled
+      - name: Regular build
         run: |
-          mvn -B -U -Pcoverage \
-          clean verify \
-          sonar:sonar \
+          mvn -B -U clean verify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sonar analysis
+        if: matrix.sonar-enabled
+        run: | # no clean
+          mvn -B sonar:sonar \
           -Dsonar.projectKey=AxonFramework_extension-kafka \
           -Dsonar.organization=axonframework \
           -Dsonar.host.url=https://sonarcloud.io \
@@ -53,17 +57,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Maven operation without Sonar
-        if: matrix.sonar-enabled != true
-        run: |
-          mvn -B -U clean verify
+      - name: Run integration tests
+        run: | # no clean
+          mvn -B -Pitest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Sonatype
         if: success()
-        run: |
-          ./mvnw -B -U deploy -DskipTests=true
+        run: | # no clean, no tests, no examples
+          ./mvnw -B -U deploy -DskipTests=true -DskipExamples=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_ID }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Run regular build
         run: |
-          mvn -B -U clean verify
+          ./mvnw -B -U clean verify
 
       - name: Run integration tests
         run: | # no clean
-          mvn -B -Pitest
+          ./mvnw -B -Pitest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Run integration tests
         run: | # no clean
-          mavn -B -Pitest
+          mvn -B -Pitest

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -11,9 +11,8 @@ jobs:
       matrix:
         include:
           - java-version: 8
-            sonar-enabled: false
           - java-version: 11
-            sonar-enabled: true
+      fail-fast: false # run both to the end
 
     steps:
       - name: Checkout code
@@ -36,22 +35,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven
 
-      - name: Maven operation with Sonar
-        if: matrix.sonar-enabled
-        run: |
-          mvn -B -U -Pcoverage \
-          clean verify \
-          sonar:sonar \
-          -Dsonar.projectKey=AxonFramework_extension-kafka \
-          -Dsonar.organization=axonframework \
-          -Dsonar.host.url=https://sonarcloud.io \
-          -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Maven operation without Sonar
-        if: matrix.sonar-enabled != true
+      - name: Run regular build
         run: |
           mvn -B -U clean verify
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run integration tests
+        run: | # no clean
+          mavn -B -Pitest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,18 +42,19 @@ immediately.
 The project is built with Apache Maven, supplied by the Maven Wrapper `mvnw`. For separate aspects of the build Maven 
 profiles are used.
 
-For a **regular** build, execute from your command line: `./mvnw`. This will run the build and execute JUnit tests
+For a **regular** build, execute from your command line: `./mvnw`. This operation will run the build and execute JUnit tests
 of all modules and package the resulting artifacts. 
 
-There is an example project supplied, and you can skip its build by passing `-DskipExamples` to your build command. 
+This repository contains an example project. 
+You can skip its build by adding `-DskipExamples` to your build command. 
 
-The long-running integration tests (starting Spring Boot Application and/or running Kafka in a TestContainer) are 
-provided and **ARE NOT** executed by default. A special **itest** build is needed to run those long-running tests. 
-If you want to run them, please call `./mvnw -Pitest` from your command line. If you need to provide additional 
-integration tests, make sure the class name ends with `IntegrationTest`.
+There are long-running integration tests present (starting Spring Boot Application and/or running Kafka in a TestContainer), which **ARE NOT** executed by default. 
+A unique `itest` build is needed to run those long-running tests. 
+If you want to run them, please call `./mvnw -Pitest` from your command line. 
+When introducing additional integration tests, make sure the class name ends with `IntegrationTest`.
 
-The project uses JaCoCo to measure test coverage of the code and will automatically generate coverage reports on regular
-and itest build. If you are interested in the overall test coverage, please run `./mvnw -Pcoverage-aggregate` 
-(without calling `clean`) after your run the **regular** and **itest** builds and check the resulting aggregated report 
+The project uses JaCoCo to measure test coverage of the code and automatically generate coverage reports on regular
+and `itest` builds. If you are interested in the overall test coverage, please run `./mvnw -Pcoverage-aggregate` 
+(without calling `clean`) after you run the **regular** and `itest` builds and check the resulting aggregated report 
 in `./coverage-report-generator/target/site/jacoco-aggregate/index.html`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,24 @@ If you're using IntelliJ IDEA, you can download the code style
 definition [here](https://github.com/AxonFramework/AxonFramework/blob/master/axon_code_style.xml). Simply import the XML
 file in under "Settings -> Code Style -> Scheme -> Import Scheme". Doing so should make the code style selectable
 immediately.
+
+### Project Build
+
+The project is built with Apache Maven, supplied by the Maven Wrapper `mvnw`. For separate aspects of the build Maven 
+profiles are used.
+
+For a **regular** build, execute from your command line: `./mvnw`. This will run the build and execute JUnit tests
+of all modules and package the resulting artifacts. 
+
+There is an example project supplied, and you can skip its build by passing `-DskipExamples` to your build command. 
+
+The long-running integration tests (starting Spring Boot Application and/or running Kafka in a TestContainer) are 
+provided and **ARE NOT** executed by default. A special **itest** build is needed to run those long-running tests. 
+If you want to run them, please call `./mvnw -Pitest` from your command line. If you need to provide additional 
+integration tests, make sure the class name ends with `IntegrationTest`.
+
+The project uses JaCoCo to measure test coverage of the code and will automatically generate coverage reports on regular
+and itest build. If you are interested in the overall test coverage, please run `./mvnw -Pcoverage-aggregate` 
+(without calling `clean`) after your run the **regular** and **itest** builds and check the resulting aggregated report 
+in `./coverage-report-generator/target/site/jacoco-aggregate/index.html`
+

--- a/coverage-report-generator/pom.xml
+++ b/coverage-report-generator/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2021. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.axonframework.extensions.kafka</groupId>
+        <artifactId>axon-kafka-parent</artifactId>
+        <version>4.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>axon-kafka-coverage-report-generator</artifactId>
+    <version>4.6.0-SNAPSHOT</version>
+
+    <name>Axon Framework Kafka Extension - Coverage Report Generator</name>
+    <description>Coverage Report Generator for the Axon Kafka Extension</description>
+
+    <organization>
+        <name>AxonIQ B.V.</name>
+        <url>https://axoniq.io</url>
+    </organization>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework.extensions.kafka</groupId>
+            <artifactId>axon-kafka</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework.extensions.kafka</groupId>
+            <artifactId>axon-kafka-spring-boot-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/KafkaPropertiesIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/KafkaPropertiesIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @EnableAutoConfiguration
 @ExtendWith(SpringExtension.class)
 @TestPropertySource("classpath:application-map-style.properties")
-class KafkaPropertiesTest {
+class KafkaPropertiesIntegrationTest {
 
     private static final String PROPERTY_KEY_ONE = "keyOne";
     private static final String PROPERTY_VALUE_ONE = "valueOne";

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
@@ -69,7 +69,7 @@ import static org.mockito.Mockito.*;
  * @author Nakul Mishra
  * @author Steven van Beelen
  */
-class KafkaAutoConfigurationTest {
+class KafkaAutoConfigurationIntegrationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(KafkaAutoConfiguration.class));

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -69,11 +69,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${test-containers.version}</version>

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherIntegrationTest.java
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.*;
  * @author Steven van Beelen
  */
 
-class AsyncFetcherTest extends KafkaContainerTest {
+class AsyncFetcherIntegrationTest extends KafkaContainerTest {
 
     private static final String TEST_TOPIC = "some-topic";
     private static final int TEST_PARTITION = 0;

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactoryIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactoryIntegrationTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.*;
  * @author Nakul Mishra
  * @author Steven van Beelen
  */
-class DefaultConsumerFactoryTest extends KafkaContainerTest {
+class DefaultConsumerFactoryIntegrationTest extends KafkaContainerTest {
 
     private static final String TEST_TOPIC = "testCreatedConsumer_ValidConfig_CanCommunicateToKafka";
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryClusteringIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryClusteringIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Lucas Campos
  * @author Nakul Mishra
  */
-class DefaultProducerFactoryClusteringTest extends KafkaContainerClusterTest {
+class DefaultProducerFactoryClusteringIntegrationTest extends KafkaContainerClusterTest {
 
     private static final String TOPIC = "testSendingMessagesUsingMultipleTransactionalProducers";
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/DefaultProducerFactoryIntegrationTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.*;
  * @author Steven van Beelen
  * @author Nakul Mishra
  */
-class DefaultProducerFactoryTest extends KafkaContainerTest {
+class DefaultProducerFactoryIntegrationTest extends KafkaContainerTest {
 
     private static final String[] TOPICS = {
             "testProducerCreation",

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherIntegrationTest.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.*;
  * @author Steven van Beelen
  * @author Nakul Mishra
  */
-class KafkaPublisherTest extends KafkaContainerTest {
+class KafkaPublisherIntegrationTest extends KafkaContainerTest {
 
     private static final String[] TOPICS = {
             "testPublishMessagesWithAckModeNoUnitOfWorkShouldBePublishedAndReadSuccessfully",

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/KafkaContainerClusterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/util/KafkaContainerClusterTest.java
@@ -9,7 +9,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * @author Lucas Campos
  */
 @Testcontainers
-public class KafkaContainerClusterTest {
+public abstract class KafkaContainerClusterTest {
 
     @Container
     protected static final KafkaContainerCluster KAFKA_CLUSTER = new KafkaContainerCluster("5.4.3", 3, 1);

--- a/pom.xml
+++ b/pom.xml
@@ -16,19 +16,19 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+    <modelVersion>4.0.0</modelVersion>
     <groupId>org.axonframework.extensions.kafka</groupId>
     <artifactId>axon-kafka-parent</artifactId>
     <version>4.6.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
     <modules>
         <module>kafka</module>
         <module>kafka-spring-boot-autoconfigure</module>
         <module>kafka-spring-boot-starter</module>
-        <module>kafka-axon-example</module>
+        <!-- Example module is inside the profile and can be switched off -->
     </modules>
-    <packaging>pom</packaging>
-
-    <modelVersion>4.0.0</modelVersion>
 
     <name>Axon Framework - Kafka Extension</name>
     <description>An Axon Framework extension allowing Kafka integration</description>
@@ -60,8 +60,8 @@
         <junit.jupiter.version>5.8.1</junit.jupiter.version>
         <mockito.version>4.0.0</mockito.version>
         <jackson.version>2.13.0</jackson.version>
-
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+        <pattern.class.test>**/*Test.*</pattern.class.test>
+        <pattern.class.itest>**/*IntegrationTest.*</pattern.class.itest>
     </properties>
 
     <dependencies>
@@ -108,7 +108,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -124,7 +123,6 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
@@ -180,6 +178,7 @@
     </dependencyManagement>
 
     <build>
+        <defaultGoal>clean package</defaultGoal>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -189,6 +188,21 @@
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -235,14 +249,14 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
                 <configuration>
+                    <excludes>
+                        <exclude>${pattern.class.itest}</exclude>
+                    </excludes>
                     <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test_*.java</include>
-                        <include>**/*Tests_*.java</include>
+                        <include>${pattern.class.test}</include>
                     </includes>
+                    <argLine>-Djava.awt.headless=true ${surefireArgLine}</argLine>
                     <systemPropertyVariables>
                         <slf4j.version>${slf4j.version}</slf4j.version>
                         <log4j.version>${log4j.version}</log4j.version>
@@ -313,10 +327,51 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <propertyName>surefireArgLine</propertyName>
+                            <destFile>${project.build.directory}/jacoco-ut.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-ut.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                            <excludes>
+                                <exclude>${pattern.class.itest}</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <profiles>
+        <profile>
+            <id>examples</id>
+            <activation>
+                <property>
+                    <name>!skipExamples</name>
+                </property>
+            </activation>
+            <modules>
+                <module>kafka-axon-example</module>
+            </modules>
+        </profile>
         <profile>
             <id>release-sign-artifacts</id>
             <activation>
@@ -345,33 +400,81 @@
                 </plugins>
             </build>
         </profile>
-
         <profile>
-            <id>coverage</id>
+            <id>itest</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
             <build>
+                <defaultGoal>verify</defaultGoal>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco-maven-plugin.version}</version>
-
                         <executions>
                             <execution>
+                                <id>prepare-integration-test</id>
+                                <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <configuration>
+                                    <propertyName>failsafeArgLine</propertyName>
+                                    <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+                                </configuration>
                             </execution>
                             <execution>
-                                <id>report</id>
-                                <phase>prepare-package</phase>
+                                <id>report-integration-test</id>
+                                <phase>post-integration-test</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
+                                <configuration>
+                                    <dataFile>${project.build.directory}/jacoco-it.exec</dataFile>
+                                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                                    <excludes>
+                                        <exclude>${pattern.class.test}</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>run-integration-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <argLine>-Djava.awt.headless=true ${failsafeArgLine}</argLine>
+                                    <includes>
+                                        <include>${pattern.class.itest}</include>
+                                    </includes>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>coverage-aggregate</id>
+            <build>
+                <defaultGoal>verify</defaultGoal>
+            </build>
+            <modules>
+                <module>coverage-report-generator</module>
+            </modules>
         </profile>
     </profiles>
 
@@ -419,6 +522,15 @@
             <organizationUrl>https://axoniq.io</organizationUrl>
             <roles>
                 <role>Lead Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Simon Zambrovski</name>
+            <email>simon.zambrovskin@holisticon.de</email>
+            <organization>Holisticon AG</organization>
+            <organizationUrl>https://holisticon.de</organizationUrl>
+            <roles>
+                <role>Developer</role>
             </roles>
         </developer>
     </developers>


### PR DESCRIPTION
Hi Folks,

as promised, my first attempt. I believe this is a good step towards a more stable and comfortable build. I added a new issue #200 to clean-up pom (especially duplicate declarations and places of version declarations) and focus in this PR on the build process only. 

Things changed:
- reorganized build to run in two phases (itests run in a separate profile `itest`)
- create coverage aggregate report (a separate profile activates creation of an coverage aggregate report `-Pcoverage-aggregate`)
- made PRs be not checked by Sonar (since the secret is not available by PR)
- separate Sonar run into a separate GH step
- made examples exclude-able from deployment to central (no reason to deploy examples to central)
- fix #199


I believe if you like this structure, it might be worth to create a Axon-Community Extension Parent POM project - to simplify the setup of the extension and containing explanations of usage and setup. This would ease your handling of extensions, if they are at least having the same parent and you could move some of the POM magic up to it...