### PR TITLE
Added properties to disable autoconfiguration for publishing and consuming events to/from Kafka

### DIFF
--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -215,9 +215,22 @@ public class KafkaProperties {
     public static class Publisher {
 
         /**
+         * Enables autoconfiguration for publishing events to Kafka
+         */
+        private boolean enabled = true;
+
+        /**
          * The confirmation mode used when publishing messages. Defaults to {@link ConfirmationMode#NONE}.
          */
         private ConfirmationMode confirmationMode = ConfirmationMode.NONE;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
 
         public ConfirmationMode getConfirmationMode() {
             return confirmationMode;
@@ -461,6 +474,11 @@ public class KafkaProperties {
     public static class Fetcher {
 
         /**
+         * Enables autoconfiguration for consuming events from Kafka
+         */
+        private boolean enabled = true;
+
+        /**
          * The time, in milliseconds, spent waiting in poll if data is not available in the buffer. If 0, returns
          * immediately with any records that are available currently in the buffer, else returns empty. Must not be
          * negative and defaults to {@code 5000} milliseconds.
@@ -475,6 +493,14 @@ public class KafkaProperties {
          * instance. Defaults to {@code 10.000} records.
          */
         private int bufferSize = 10_000;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
 
         public long getPollTimeout() {
             return pollTimeout;

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -215,7 +215,7 @@ public class KafkaProperties {
     public static class Publisher {
 
         /**
-         * Enables autoconfiguration for publishing events to Kafka
+         * Enables auto-configuration for publishing events to Kafka. Defaults to {@code true}.
          */
         private boolean enabled = true;
 
@@ -474,7 +474,7 @@ public class KafkaProperties {
     public static class Fetcher {
 
         /**
-         * Enables autoconfiguration for consuming events from Kafka
+         * Enables auto-configuration for consuming events from Kafka. Defaults to {@code true}.
          */
         private boolean enabled = true;
 

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -47,6 +47,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -67,6 +68,9 @@ import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEve
  * @since 4.0
  */
 @Configuration
+@ConditionalOnExpression(
+        "${axon.kafka.publisher.enabled:true} or ${axon.kafka.fetcher.enabled:true}"
+)
 @ConditionalOnClass(KafkaPublisher.class)
 @AutoConfigureAfter(AxonAutoConfiguration.class)
 @AutoConfigureBefore(InfraConfiguration.class)

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -91,6 +91,7 @@ public class KafkaAutoConfiguration {
 
     @Bean("axonKafkaProducerFactory")
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "axon.kafka.publisher", name = "enabled", havingValue = "true", matchIfMissing = true)
     public ProducerFactory<String, byte[]> kafkaProducerFactory() {
         ConfirmationMode confirmationMode = properties.getPublisher().getConfirmationMode();
         String transactionIdPrefix = properties.getProducer().getTransactionIdPrefix();
@@ -123,6 +124,7 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutDown")
     @ConditionalOnBean({ProducerFactory.class, KafkaMessageConverter.class})
+    @ConditionalOnProperty(prefix = "axon.kafka.publisher", name = "enabled", havingValue = "true", matchIfMissing = true)
     public KafkaPublisher<String, byte[]> kafkaPublisher(ProducerFactory<String, byte[]> axonKafkaProducerFactory,
                                                          KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
                                                          AxonConfiguration configuration) {
@@ -138,6 +140,7 @@ public class KafkaAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean({KafkaPublisher.class})
+    @ConditionalOnProperty(prefix = "axon.kafka.publisher", name = "enabled", havingValue = "true", matchIfMissing = true)
     public KafkaEventPublisher<String, byte[]> kafkaEventPublisher(KafkaPublisher<String, byte[]> kafkaPublisher,
                                                                    KafkaProperties kafkaProperties,
                                                                    EventProcessingConfigurer eventProcessingConfigurer) {
@@ -175,12 +178,14 @@ public class KafkaAutoConfiguration {
 
     @Bean("axonKafkaConsumerFactory")
     @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "axon.kafka.fetcher", name = "enabled", havingValue = "true", matchIfMissing = true)
     public ConsumerFactory<String, byte[]> kafkaConsumerFactory() {
         return new DefaultConsumerFactory<>(properties.buildConsumerProperties());
     }
 
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutdown")
+    @ConditionalOnProperty(prefix = "axon.kafka.fetcher", name = "enabled", havingValue = "true", matchIfMissing = true)
     public Fetcher<?, ?, ?> kafkaFetcher() {
         return AsyncFetcher.builder()
                            .pollTimeout(properties.getFetcher().getPollTimeout())
@@ -191,6 +196,7 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class, Fetcher.class})
     @Conditional(StreamingProcessorModeCondition.class)
+    @ConditionalOnProperty(prefix = "axon.kafka.fetcher", name = "enabled", havingValue = "true", matchIfMissing = true)
     public StreamableKafkaMessageSource<String, byte[]> streamableKafkaMessageSource(
             ConsumerFactory<String, byte[]> kafkaConsumerFactory,
             Fetcher<String, byte[], KafkaEventMessage> kafkaFetcher,

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -91,7 +91,7 @@ public class KafkaAutoConfiguration {
 
     @Bean("axonKafkaProducerFactory")
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "axon.kafka.publisher", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(name = "axon.kafka.publisher.enabled", havingValue = "true", matchIfMissing = true)
     public ProducerFactory<String, byte[]> kafkaProducerFactory() {
         ConfirmationMode confirmationMode = properties.getPublisher().getConfirmationMode();
         String transactionIdPrefix = properties.getProducer().getTransactionIdPrefix();
@@ -124,7 +124,7 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutDown")
     @ConditionalOnBean({ProducerFactory.class, KafkaMessageConverter.class})
-    @ConditionalOnProperty(prefix = "axon.kafka.publisher", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(name = "axon.kafka.publisher.enabled", havingValue = "true", matchIfMissing = true)
     public KafkaPublisher<String, byte[]> kafkaPublisher(ProducerFactory<String, byte[]> axonKafkaProducerFactory,
                                                          KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
                                                          AxonConfiguration configuration) {
@@ -140,7 +140,7 @@ public class KafkaAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnBean({KafkaPublisher.class})
-    @ConditionalOnProperty(prefix = "axon.kafka.publisher", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(name = "axon.kafka.publisher.enabled", havingValue = "true", matchIfMissing = true)
     public KafkaEventPublisher<String, byte[]> kafkaEventPublisher(KafkaPublisher<String, byte[]> kafkaPublisher,
                                                                    KafkaProperties kafkaProperties,
                                                                    EventProcessingConfigurer eventProcessingConfigurer) {
@@ -178,14 +178,14 @@ public class KafkaAutoConfiguration {
 
     @Bean("axonKafkaConsumerFactory")
     @ConditionalOnMissingBean
-    @ConditionalOnProperty(prefix = "axon.kafka.fetcher", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(name = "axon.kafka.fetcher.enabled", havingValue = "true", matchIfMissing = true)
     public ConsumerFactory<String, byte[]> kafkaConsumerFactory() {
         return new DefaultConsumerFactory<>(properties.buildConsumerProperties());
     }
 
     @ConditionalOnMissingBean
     @Bean(destroyMethod = "shutdown")
-    @ConditionalOnProperty(prefix = "axon.kafka.fetcher", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(name = "axon.kafka.fetcher.enabled", havingValue = "true", matchIfMissing = true)
     public Fetcher<?, ?, ?> kafkaFetcher() {
         return AsyncFetcher.builder()
                            .pollTimeout(properties.getFetcher().getPollTimeout())
@@ -196,7 +196,7 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     @ConditionalOnBean({ConsumerFactory.class, KafkaMessageConverter.class, Fetcher.class})
     @Conditional(StreamingProcessorModeCondition.class)
-    @ConditionalOnProperty(prefix = "axon.kafka.fetcher", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(name = "axon.kafka.fetcher.enabled", havingValue = "true", matchIfMissing = true)
     public StreamableKafkaMessageSource<String, byte[]> streamableKafkaMessageSource(
             ConsumerFactory<String, byte[]> kafkaConsumerFactory,
             Fetcher<String, byte[], KafkaEventMessage> kafkaFetcher,

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
@@ -281,6 +281,24 @@ class KafkaAutoConfigurationIntegrationTest {
     }
 
     @Test
+    void testAutoConfigurationWithPublishingAndFetchingDisabled() {
+        this.contextRunner.withUserConfiguration(TestConfiguration.class)
+                .withPropertyValues(
+                        "axon.kafka.publisher.enabled=false",
+                        "axon.kafka.fetcher.enabled=false"
+                ).run(context -> {
+                    // Required bean assertions
+                    assertEquals(0, context.getBeanNamesForType(KafkaMessageConverter.class).length);
+                    assertEquals(0, context.getBeanNamesForType(ProducerFactory.class).length);
+                    assertEquals(0, context.getBeanNamesForType(KafkaPublisher.class).length);
+                    assertEquals(0, context.getBeanNamesForType(KafkaEventPublisher.class).length);
+                    assertEquals(0, context.getBeanNamesForType(ConsumerFactory.class).length);
+                    assertEquals(0, context.getBeanNamesForType(Fetcher.class).length);
+                    assertEquals(0, context.getBeanNamesForType(StreamableKafkaMessageSource.class).length);
+                });
+    }
+
+    @Test
     void testConsumerPropertiesAreAdjustedAsExpected() {
         this.contextRunner.withUserConfiguration(TestConfiguration.class)
                           .withPropertyValues(


### PR DESCRIPTION
This MR add ability to disable autoconfiguration publishing and consuming events to/from Kafka via properties `axon.kafka.publisher.enabled` and `axon.kafka.fetcher.enabled`