### PR TITLE
Bump Kafka version to 3.1.0, needs jackson-databind to compile

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -54,6 +54,11 @@
             <version>${kafka.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -61,7 +66,6 @@
             <version>${jmh-core.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Main -->
         <axon.version>4.5.5</axon.version>
-        <kafka.version>2.8.0</kafka.version>
+        <kafka.version>3.1.0</kafka.version>
         <!-- Spring -->
         <spring.boot.version>2.6.4</spring.boot.version>
         <!-- Logging -->


### PR DESCRIPTION
Bump Kafka version to 3.1.0, needs `jackson-databind` to compile

This pull request resolves #237.