### PR TITLE
Updated serializer configuration and made them lazy

### DIFF
--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
@@ -16,6 +16,10 @@
 
 package org.axonframework.extensions.kafka.autoconfig;
 
+import com.thoughtworks.xstream.XStream;
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SslConfigs;
@@ -44,23 +48,28 @@ import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
 import org.axonframework.monitoring.MessageMonitor;
 import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.axonframework.spring.config.AxonConfiguration;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.File;
-import java.util.Collections;
-import java.util.Map;
-
 import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link KafkaAutoConfiguration}, verifying the minimal set of requirements and full fledged adjustments
@@ -555,7 +564,9 @@ class KafkaAutoConfigurationIntegrationTest {
 
         @Bean
         public Serializer eventSerializer() {
-            return XStreamSerializer.defaultSerializer();
+            return XStreamSerializer.builder()
+                                    .xStream(new XStream(new CompactDriver()))
+                                    .build();
         }
 
         @Bean

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSource.java
@@ -162,7 +162,8 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
                                                                          .build();
 
         /**
-         * Sets the {@link Serializer} used to serialize and deserialize messages.
+         * Sets the {@link Serializer} used to serialize and deserialize messages. Defaults to a {@link
+         * XStreamSerializer}.
          *
          * @param serializer a {@link Serializer} used to serialize and deserialize messages
          * @return the current Builder instance, for fluent interfacing

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSource.java
@@ -167,7 +167,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
          * @param serializer a {@link Serializer} used to serialize and deserialize messages
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder serializer(Serializer serializer) {
+        public Builder<K, V> serializer(Serializer serializer) {
             assertNonNull(serializer, "The Serializer may not be null");
             this.serializer = () -> serializer;
             return this;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
@@ -16,6 +16,20 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer.subscribable;
 
+import com.thoughtworks.xstream.XStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.axonframework.common.AxonConfigurationException;
@@ -27,22 +41,11 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory
 import org.axonframework.extensions.kafka.eventhandling.consumer.DefaultConsumerFactory;
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
 import org.axonframework.messaging.SubscribableMessageSource;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 import static org.axonframework.common.BuilderUtils.assertThat;
@@ -210,13 +213,22 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
         private String groupId;
         private ConsumerFactory<K, V> consumerFactory;
         private Fetcher<K, V, EventMessage<?>> fetcher;
-        @SuppressWarnings({"unchecked", "squid:S1874"})
-        private KafkaMessageConverter<K, V> messageConverter =
-                (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
-                                                                          .serializer(XStreamSerializer.defaultSerializer())
-                                                                          .build();
+        private KafkaMessageConverter<K, V> messageConverter;
         private boolean autoStart = false;
         private int consumerCount = 1;
+        private Supplier<Serializer> serializer;
+
+        /**
+         * Sets the {@link Serializer} used to serialize and deserialize messages.
+         *
+         * @param serializer a {@link Serializer} used to serialize and deserialize messages
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder serializer(Serializer serializer) {
+            assertNonNull(serializer, "The Serializer may not be null");
+            this.serializer = () -> serializer;
+            return this;
+        }
 
         /**
          * Set the Kafka {@code topics} to read {@link org.axonframework.eventhandling.EventMessage}s from. Defaults to
@@ -362,6 +374,23 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
             assertNonNull(groupId, "The Consumer Group Id is a hard requirement and should be provided");
             assertNonNull(consumerFactory, "The ConsumerFactory is a hard requirement and should be provided");
             assertNonNull(fetcher, "The Fetcher is a hard requirement and should be provided");
+            if (serializer == null) {
+                logger.warn(
+                        "The default XStreamSerializer is used, whereas it is strongly recommended to "
+                                + "configure the security context of the XStream instance.",
+                        new AxonConfigurationException(
+                                "A default XStreamSerializer is used, without specifying the security context"
+                        )
+                );
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
+            }
+            if (messageConverter == null) {
+                messageConverter = (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
+                                                                                             .serializer(serializer.get())
+                                                                                             .build();
+            }
         }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
@@ -216,9 +216,7 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
         private KafkaMessageConverter<K, V> messageConverter;
         private boolean autoStart = false;
         private int consumerCount = 1;
-        private Supplier<Serializer> serializer = () -> XStreamSerializer.builder()
-                                                                         .xStream(new XStream(new CompactDriver()))
-                                                                         .build();
+        private Supplier<Serializer> serializer;
 
         /**
          * Sets the {@link Serializer} used to serialize and deserialize messages. Defaults to a {@link
@@ -377,6 +375,18 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
             assertNonNull(groupId, "The Consumer Group Id is a hard requirement and should be provided");
             assertNonNull(consumerFactory, "The ConsumerFactory is a hard requirement and should be provided");
             assertNonNull(fetcher, "The Fetcher is a hard requirement and should be provided");
+            if (serializer == null) {
+                logger.warn(
+                        "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
+                                + " the security context of the XStream instance.",
+                        new AxonConfigurationException(
+                                "A default XStreamSerializer is used, without specifying the security context"
+                        )
+                );
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
+            }
             if (messageConverter == null) {
                 messageConverter = (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
                                                                                              .serializer(serializer.get())

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
@@ -226,7 +226,7 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
          * @param serializer a {@link Serializer} used to serialize and deserialize messages
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder serializer(Serializer serializer) {
+        public Builder<K, V> serializer(Serializer serializer) {
             assertNonNull(serializer, "The Serializer may not be null");
             this.serializer = () -> serializer;
             return this;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
@@ -221,7 +221,8 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
                                                                          .build();
 
         /**
-         * Sets the {@link Serializer} used to serialize and deserialize messages.
+         * Sets the {@link Serializer} used to serialize and deserialize messages. Defaults to a {@link
+         * XStreamSerializer}.
          *
          * @param serializer a {@link Serializer} used to serialize and deserialize messages
          * @return the current Builder instance, for fluent interfacing

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -255,7 +255,9 @@ public class KafkaPublisher<K, V> {
         private MessageMonitor<? super EventMessage<?>> messageMonitor = NoOpMessageMonitor.instance();
         private TopicResolver topicResolver = m -> Optional.of(DEFAULT_TOPIC);
         private long publisherAckTimeout = 1_000;
-        private Supplier<Serializer> serializer;
+        private Supplier<Serializer> serializer = () -> XStreamSerializer.builder()
+                                                                         .xStream(new XStream(new CompactDriver()))
+                                                                         .build();
 
         /**
          * Sets the {@link Serializer} used to serialize and deserialize messages.
@@ -380,18 +382,6 @@ public class KafkaPublisher<K, V> {
         @SuppressWarnings("WeakerAccess")
         protected void validate() throws AxonConfigurationException {
             assertNonNull(producerFactory, "The ProducerFactory is a hard requirement and should be provided");
-            if (serializer == null) {
-                logger.warn(
-                        "The default XStreamSerializer is used, whereas it is strongly recommended to "
-                                + "configure the security context of the XStream instance.",
-                        new AxonConfigurationException(
-                                "A default XStreamSerializer is used, without specifying the security context"
-                        )
-                );
-                serializer = () -> XStreamSerializer.builder()
-                                                    .xStream(new XStream(new CompactDriver()))
-                                                    .build();
-            }
             if (messageConverter == null) {
                 messageConverter = (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
                                                                                              .serializer(serializer.get())

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -260,7 +260,8 @@ public class KafkaPublisher<K, V> {
                                                                          .build();
 
         /**
-         * Sets the {@link Serializer} used to serialize and deserialize messages.
+         * Sets the {@link Serializer} used to serialize and deserialize messages. Defaults to a {@link
+         * XStreamSerializer}.
          *
          * @param serializer a {@link Serializer} used to serialize and deserialize messages
          * @return the current Builder instance, for fluent interfacing

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -255,9 +255,7 @@ public class KafkaPublisher<K, V> {
         private MessageMonitor<? super EventMessage<?>> messageMonitor = NoOpMessageMonitor.instance();
         private TopicResolver topicResolver = m -> Optional.of(DEFAULT_TOPIC);
         private long publisherAckTimeout = 1_000;
-        private Supplier<Serializer> serializer = () -> XStreamSerializer.builder()
-                                                                         .xStream(new XStream(new CompactDriver()))
-                                                                         .build();
+        private Supplier<Serializer> serializer;
 
         /**
          * Sets the {@link Serializer} used to serialize and deserialize messages. Defaults to a {@link
@@ -383,6 +381,18 @@ public class KafkaPublisher<K, V> {
         @SuppressWarnings("WeakerAccess")
         protected void validate() throws AxonConfigurationException {
             assertNonNull(producerFactory, "The ProducerFactory is a hard requirement and should be provided");
+            if (serializer == null) {
+                logger.warn(
+                        "The default XStreamSerializer is used, whereas it is strongly recommended to configure"
+                                + " the security context of the XStream instance.",
+                        new AxonConfigurationException(
+                                "A default XStreamSerializer is used, without specifying the security context"
+                        )
+                );
+                serializer = () -> XStreamSerializer.builder()
+                                                    .xStream(new XStream(new CompactDriver()))
+                                                    .build();
+            }
             if (messageConverter == null) {
                 messageConverter = (KafkaMessageConverter<K, V>) DefaultKafkaMessageConverter.builder()
                                                                                              .serializer(serializer.get())

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisher.java
@@ -265,7 +265,7 @@ public class KafkaPublisher<K, V> {
          * @param serializer a {@link Serializer} used to serialize and deserialize messages
          * @return the current Builder instance, for fluent interfacing
          */
-        public Builder serializer(Serializer serializer) {
+        public Builder<K, V> serializer(Serializer serializer) {
             assertNonNull(serializer, "The Serializer may not be null");
             this.serializer = () -> serializer;
             return this;


### PR DESCRIPTION
The goal for this PR is to do the same we did on Framework, making Serializers lazy and only initializing them if the user doesn't provide one.

It has an added benefit of not always initializing XStream.
For making it work, the initialization of the `messageConverter` was also pushed to the end of the builder call.

I am not sure we have meaningful tests to be added in this case.