### PR TITLE
Remove the use of a consumer group for StreamableKafkaMessageSource.

### DIFF
--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerFactory.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,16 +25,20 @@ import org.apache.kafka.clients.consumer.Consumer;
  * @param <V> the value type of a build {@link Consumer} instance
  * @author Nakul Mishra
  * @author Steven van Beelen
+ * @author Gerard Klijs
  * @since 4.0
  */
 @FunctionalInterface
 public interface ConsumerFactory<K, V> {
 
     /**
-     * Create a {@link Consumer} that should be part of the Consumer Group with the given {@code groupId}.
+     * Create a {@link Consumer} that should be part of the Consumer Group with the given {@code groupId}, or without a
+     * consumer group if called with {@code null}.
      *
-     * @param groupId a {@link String} defining the group the constructed {@link Consumer} will be a part of
-     * @return a {@link Consumer} which is part of Consumer Group with the given {@code groupId}
+     * @param groupId a {@link String} defining the group the constructed {@link Consumer} will be a part of, this can
+     *                be {@code null} to not add it to a group.
+     * @return a {@link Consumer} which is part of Consumer Group with the given {@code groupId}, or without a groupId
+     * when called with {@code null}.
      */
     Consumer<K, V> createConsumer(String groupId);
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerSeekUtil.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/ConsumerSeekUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.KafkaTrackingToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Contains static util functions related to the Kafka consumer related to seeking to certain offsets.
+ *
+ * @author Gerard Klijs
+ * @since 4.5.4
+ */
+public class ConsumerSeekUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private ConsumerSeekUtil() {
+        //prevent instantiation
+    }
+
+    /**
+     * Assigns the correct {@link TopicPartition partitions} to the consumer, and seeks to the correct offset, using the
+     * {@link KafkaTrackingToken}, defaulting to the head of the partition. So for each {@link TopicPartition partition}
+     * that belongs to the {@code topics}, either it will start reading from the next record of the partition, if
+     * included in the token, or else from the start.
+     *
+     * @param consumer      a Kafka consumer instance
+     * @param tokenSupplier a function that returns the current {@link KafkaTrackingToken}
+     * @param topics        a list of topics that will be assigned to the consumer
+     */
+    public static void seekToCurrentPositions(Consumer<?, ?> consumer, Supplier<KafkaTrackingToken> tokenSupplier,
+                                              List<String> topics) {
+        List<TopicPartition> all = consumer.listTopics().entrySet()
+                                           .stream()
+                                           .filter(e -> topics.contains(e.getKey()))
+                                           .flatMap(e -> e.getValue().stream())
+                                           .map(partitionInfo -> new TopicPartition(partitionInfo.topic(),
+                                                                                    partitionInfo.partition()))
+                                           .collect(Collectors.toList());
+        consumer.assign(all);
+        KafkaTrackingToken currentToken = tokenSupplier.get();
+        all.forEach(assignedPartition -> {
+            Map<TopicPartition, Long> tokenPartitionPositions = currentToken.getPositions();
+
+            long offset = 0L;
+            if (tokenPartitionPositions.containsKey(assignedPartition)) {
+                offset = tokenPartitionPositions.get(assignedPartition) + 1;
+            }
+
+            logger.info("Seeking topic-partition [{}] with offset [{}]", assignedPartition, offset);
+            consumer.seek(assignedPartition, offset);
+        });
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactory.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactory.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,13 +58,14 @@ public class DefaultConsumerFactory<K, V> implements ConsumerFactory<K, V> {
 
     @Override
     public Consumer<K, V> createConsumer(String groupId) {
-        if (this.consumerConfiguration.remove(GROUP_ID_CONFIG) != null) {
+        Map<String, Object> configuration = new HashMap<>(this.consumerConfiguration);
+        if (configuration.remove(GROUP_ID_CONFIG) != null) {
             logger.warn("Found a global {} whilst it is required to be provided consciously", GROUP_ID_CONFIG);
         }
-
-        Map<String, Object> consumerConfiguration = new HashMap<>(this.consumerConfiguration);
-        consumerConfiguration.put(GROUP_ID_CONFIG, groupId);
-        return new KafkaConsumer<>(consumerConfiguration);
+        if (groupId != null) {
+            configuration.put(GROUP_ID_CONFIG, groupId);
+        }
+        return new KafkaConsumer<>(configuration);
     }
 
     /**

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListener.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/TrackingTokenConsumerRebalanceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@ package org.axonframework.extensions.kafka.eventhandling.consumer.streamable;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
+import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerSeekUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -40,7 +42,11 @@ import java.util.function.Supplier;
  * @param <V> the value type of the records the {@link Consumer} polls
  * @author Steven van Beelen
  * @since 4.0
+ * @deprecated functionality moved to {@link ConsumerSeekUtil#seekToCurrentPositions(Consumer,
+ * Supplier, List)} when group id was removed from the consumer.
  */
+@Deprecated
+@SuppressWarnings("squid:S1133") //removing would be a breaking change and can only be done in a major release
 public class TrackingTokenConsumerRebalanceListener<K, V> implements ConsumerRebalanceListener {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.Kafk
 import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.SortedKafkaMessageBuffer;
 import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.StreamableKafkaMessageSource;
 import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.TrackingRecordConverter;
-import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.TrackingTokenConsumerRebalanceListener;
 import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory;
 import org.axonframework.extensions.kafka.eventhandling.util.KafkaAdminUtils;
 import org.axonframework.extensions.kafka.eventhandling.util.KafkaContainerTest;
@@ -44,9 +43,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
-import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.DEFAULT_GROUP_ID;
 import static org.axonframework.extensions.kafka.eventhandling.util.ConsumerConfigUtil.consumerFactory;
 import static org.axonframework.extensions.kafka.eventhandling.util.ProducerConfigUtil.producerFactory;
 import static org.junit.jupiter.api.Assertions.*;
@@ -186,12 +185,23 @@ class AsyncFetcherTest extends KafkaContainerTest {
         testPositions.put(new TopicPartition(topic, 4), 0L);
         KafkaTrackingToken testStartToken = KafkaTrackingToken.newInstance(testPositions);
 
-        Consumer<String, String> testConsumer = consumerFactory(getBootstrapServers()).createConsumer(
-                DEFAULT_GROUP_ID);
-        testConsumer.subscribe(
-                Collections.singletonList(topic),
-                new TrackingTokenConsumerRebalanceListener<>(testConsumer, () -> testStartToken)
-        );
+        Consumer<String, String> testConsumer = consumerFactory(getBootstrapServers()).createConsumer(null);
+        List<TopicPartition> all = testConsumer.listTopics().entrySet()
+                                               .stream()
+                                               .filter(e -> e.getKey().equals(topic))
+                                               .flatMap(e -> e.getValue().stream())
+                                               .map(partitionInfo -> new TopicPartition(partitionInfo.topic(),
+                                                                                        partitionInfo.partition()))
+                                               .collect(Collectors.toList());
+        testConsumer.assign(all);
+        all.forEach(assignedPartition -> {
+            Map<TopicPartition, Long> tokenPartitionPositions = testStartToken.getPositions();
+            long offset = 0L;
+            if (tokenPartitionPositions.containsKey(assignedPartition)) {
+                offset = tokenPartitionPositions.get(assignedPartition) + 1;
+            }
+            testConsumer.seek(assignedPartition, offset);
+        });
 
         testSubject.poll(
                 testConsumer,

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactoryTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/DefaultConsumerFactoryTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2010-2018. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Fixes https://github.com/AxonFramework/extension-kafka/issues/273 by instead of relying on a different consumer id each time, to ensure all the partitions are consumed, setting the partitions manually.