### PR TITLE
Changes the buffer so that errors from the fetcher will be thrown once the buffer is empty.

### DIFF
--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,12 +87,30 @@ public class AsyncFetcher<K, V, E> implements Fetcher<K, V, E> {
         this.requirePoolShutdown = builder.requirePoolShutdown;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Registration poll(Consumer<K, V> consumer,
                              RecordConverter<K, V, E> recordConverter,
                              EventConsumer<E> eventConsumer) {
+        return poll(consumer, recordConverter, eventConsumer,
+                    e -> logger.warn("Error from fetching thread, should be handled properly", e));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Registration poll(Consumer<K, V> consumer, RecordConverter<K, V, E> recordConverter,
+                             EventConsumer<E> eventConsumer, RuntimeErrorHandler runtimeErrorHandler) {
         FetchEventsTask<K, V, E> fetcherTask =
-                new FetchEventsTask<>(consumer, pollTimeout, recordConverter, eventConsumer, activeFetchers::remove);
+                new FetchEventsTask<>(consumer,
+                                      pollTimeout,
+                                      recordConverter,
+                                      eventConsumer,
+                                      activeFetchers::remove,
+                                      runtimeErrorHandler);
 
         activeFetchers.add(fetcherTask);
         executorService.execute(fetcherTask);

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventException.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.axonframework.common.AxonException;
+
+/**
+ * Exception thrown when there is an error while either fetching records from Kafka, or processing them.
+ *
+ * @author Gerard Klijs
+ * @since 4.5.4
+ */
+public class FetchEventException extends AxonException {
+
+    /**
+     * Creates a new {@link FetchEventException}
+     *
+     * @param message some info about the exception
+     */
+    public FetchEventException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new {@link FetchEventException}
+     *
+     * @param message some info about the exception
+     * @param cause   the {@link Throwable} that is the cause of the exception
+     */
+    public FetchEventException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventException.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventException.java
@@ -36,7 +36,7 @@ public class FetchEventException extends AxonException {
     }
 
     /**
-     * Creates a new {@link FetchEventException}
+     * Creates a new {@link FetchEventException}.
      *
      * @param message some info about the exception
      * @param cause   the {@link Throwable} that is the cause of the exception

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventException.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventException.java
@@ -27,7 +27,7 @@ import org.axonframework.common.AxonException;
 public class FetchEventException extends AxonException {
 
     /**
-     * Creates a new {@link FetchEventException}
+     * Creates a new {@link FetchEventException}.
      *
      * @param message some info about the exception
      */

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/Fetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,10 +46,34 @@ public interface Fetcher<K, V, E> {
      * @param eventConsumer   a {@link EventConsumer} instance which will consume the converted records
      * @return a close handler of type {@link org.axonframework.common.Registration} to stop the {@link Fetcher}
      * operation
+     * @deprecated instead {@link #poll(Consumer, RecordConverter, EventConsumer, RuntimeErrorHandler)} should be used,
+     * so including an error handler.
      */
+    @Deprecated
+    @SuppressWarnings("squid:S1133")
+    //Removal will break the API, so can only be done in a new major version.
     Registration poll(Consumer<K, V> consumer,
                       RecordConverter<K, V, E> recordConverter,
                       EventConsumer<E> eventConsumer);
+
+    /**
+     * Instruct this Fetcher to start polling message through the provided {@link Consumer}. After retrieval, the {@link
+     * org.apache.kafka.clients.consumer.ConsumerRecords} will be converted by the given {@code recordConverter} and
+     * there after consumed by the given {@code recordConsumer}. A {@link Registration} will be returned to cancel
+     * message consumption and conversion.
+     *
+     * @param consumer            the {@link Consumer} used to consume message from a Kafka topic
+     * @param recordConverter     a {@link RecordConverter} instance which will convert the "consumed" {@link
+     *                            org.apache.kafka.clients.consumer.ConsumerRecords} in to a  List of {@code E}
+     * @param eventConsumer       a {@link EventConsumer} instance which will consume the converted records
+     * @param runtimeErrorHandler a {@link RuntimeErrorHandler} function used to handle errors
+     * @return a close handler of type {@link org.axonframework.common.Registration} to stop the {@link Fetcher}
+     * operation
+     */
+    Registration poll(Consumer<K, V> consumer,
+                      RecordConverter<K, V, E> recordConverter,
+                      EventConsumer<E> eventConsumer,
+                      RuntimeErrorHandler runtimeErrorHandler);
 
     /**
      * Shuts the fetcher down, closing any resources used by this fetcher.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RuntimeErrorHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RuntimeErrorHandler.java
@@ -17,7 +17,10 @@
 package org.axonframework.extensions.kafka.eventhandling.consumer;
 
 /**
- * Used to implement an error handler such that exception from one thread can be passed to another thread.
+ * Used to implement an error handler such that exceptions from one thread can be passed to another thread.
+ *
+ * @author Gerard Klijs
+ * @since 4.5.4
  */
 @FunctionalInterface
 public interface RuntimeErrorHandler {

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RuntimeErrorHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RuntimeErrorHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+/**
+ * Used to implement an error handler such that exception from one thread can be passed to another thread.
+ */
+@FunctionalInterface
+public interface RuntimeErrorHandler {
+
+    /**
+     * Error that is passed to another thread, to be handled there
+     *
+     * @param exception, the {@link RuntimeException} that's need to be handled.
+     */
+    void handle(RuntimeException exception);
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RuntimeErrorHandler.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/RuntimeErrorHandler.java
@@ -26,7 +26,7 @@ package org.axonframework.extensions.kafka.eventhandling.consumer;
 public interface RuntimeErrorHandler {
 
     /**
-     * Error that is passed to another thread, to be handled there
+     * Error that is passed to another thread, to be handled there.
      *
      * @param exception, the {@link RuntimeException} that's need to be handled.
      */

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/Buffer.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/Buffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2019. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer.streamable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -26,9 +29,12 @@ import java.util.concurrent.TimeUnit;
  * @param <E> the type of the element contained in the buffer
  * @author Nakul Mishra
  * @author Steven van Beelen
+ * @author Gerard Klijs
  * @since 4.0
  */
 public interface Buffer<E> {
+
+    Logger logger = LoggerFactory.getLogger(Buffer.class);
 
     /**
      * Inserts the provided element in this buffer, waiting for space to become available if the buffer is full.
@@ -104,4 +110,13 @@ public interface Buffer<E> {
      * Removes all of the messages from this buffer.
      */
     void clear();
+
+    /**
+     * Can be used to set some exception originating from another thread, that should pop up using the buffer.
+     *
+     * @param exception the exception thrown from a thread that fills the buffer.
+     */
+    default void setException(RuntimeException exception) {
+        logger.warn("setException was called, but is not implemented to do something with it", exception);
+    }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/SortedKafkaMessageBuffer.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/SortedKafkaMessageBuffer.java
@@ -321,5 +321,15 @@ public class SortedKafkaMessageBuffer<E extends Comparable<?> & KafkaRecordMetaD
     @Override
     public void setException(RuntimeException exception) {
         possibleException.set(exception);
+        try {
+            lock.lockInterruptibly();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        try {
+            this.notEmpty.signal();
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSource.java
@@ -57,6 +57,7 @@ import static org.axonframework.common.BuilderUtils.assertThat;
  * @param <V> the value type of {@link ConsumerRecords} to consume, fetch and convert
  * @author Nakul Mishra
  * @author Steven van Beelen
+ * @author Gerard Klijs
  * @since 4.0
  */
 public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSource<TrackedEventMessage<?>> {
@@ -119,7 +120,7 @@ public class StreamableKafkaMessageSource<K, V> implements StreamableMessageSour
         ConsumerSeekUtil.seekToCurrentPositions(consumer, recordConverter::currentToken, topics);
 
         Buffer<KafkaEventMessage> buffer = bufferFactory.get();
-        Registration closeHandler = fetcher.poll(consumer, recordConverter, buffer::putAll);
+        Registration closeHandler = fetcher.poll(consumer, recordConverter, buffer::putAll, buffer::setException);
         return new KafkaMessageStream(buffer, closeHandler);
     }
 

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/FailingConsumerErrorThroughBufferTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/FailingConsumerErrorThroughBufferTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.axonframework.extensions.kafka.eventhandling.consumer.streamable;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.KafkaException;
+import org.axonframework.common.stream.BlockingStream;
+import org.axonframework.eventhandling.TrackedEventMessage;
+import org.axonframework.extensions.kafka.eventhandling.consumer.AsyncFetcher;
+import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory;
+import org.axonframework.extensions.kafka.eventhandling.consumer.FetchEventException;
+import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher;
+import org.junit.jupiter.api.*;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * Kafka tests asserting an error should pop up if there is on error with the consumer. This error pops up via a call to
+ * {@link Buffer#setException(RuntimeException)} setException} method in the buffer which pops up once the buffer is
+ * empty to the consumer of the {@link StreamableKafkaMessageSource}.
+ *
+ * @author Gerard Klijs
+ */
+class FailingConsumerErrorThroughBufferTest {
+
+    private static final String TEST_TOPIC = "failing_consumer_test";
+    private Fetcher<String, byte[], KafkaEventMessage> fetcher;
+    private ConsumerFactory<String, byte[]> consumerFactory;
+    private Consumer<String, byte[]> consumer;
+
+    @BeforeEach
+    void setUp() {
+        consumer = mock(Consumer.class);
+        doThrow(new KafkaException("poll error"))
+                .when(consumer)
+                .poll(any());
+        consumerFactory = new MockFactory();
+        fetcher = AsyncFetcher.<String, byte[], KafkaEventMessage>builder()
+                              .pollTimeout(300)
+                              .build();
+    }
+
+    @AfterEach
+    void shutdown() {
+        fetcher.shutdown();
+    }
+
+    @Test
+    void testFetchEventExceptionAfterFailedPollWhenCallingNextAvailable() {
+        StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
+                StreamableKafkaMessageSource.<String, byte[]>builder()
+                                            .topics(Collections.singletonList(TEST_TOPIC))
+                                            .consumerFactory(consumerFactory)
+                                            .fetcher(fetcher)
+                                            .build();
+        BlockingStream<TrackedEventMessage<?>> stream = streamableMessageSource.openStream(null);
+        assertThrows(FetchEventException.class, stream::nextAvailable);
+        stream.close();
+    }
+
+    @Test
+    void testFetchEventExceptionAfterFailedPollWhenCallingHasNextAvailable() {
+        StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
+                StreamableKafkaMessageSource.<String, byte[]>builder()
+                                            .topics(Collections.singletonList(TEST_TOPIC))
+                                            .consumerFactory(consumerFactory)
+                                            .fetcher(fetcher)
+                                            .build();
+        BlockingStream<TrackedEventMessage<?>> stream = streamableMessageSource.openStream(null);
+        await().atMost(Duration.ofSeconds(1L)).until(() -> {
+            try {
+                stream.hasNextAvailable();
+                return false;
+            } catch (FetchEventException e) {
+                return true;
+            }
+        });
+        stream.close();
+    }
+
+    @Test
+    void testFetchEventExceptionAfterFailedPollWhenCallingPeek() {
+        StreamableKafkaMessageSource<String, byte[]> streamableMessageSource =
+                StreamableKafkaMessageSource.<String, byte[]>builder()
+                                            .topics(Collections.singletonList(TEST_TOPIC))
+                                            .consumerFactory(consumerFactory)
+                                            .fetcher(fetcher)
+                                            .build();
+        BlockingStream<TrackedEventMessage<?>> stream = streamableMessageSource.openStream(null);
+        await().atMost(Duration.ofSeconds(1L)).until(() -> {
+            try {
+                stream.peek();
+                return false;
+            } catch (FetchEventException e) {
+                return true;
+            }
+        });
+        stream.close();
+    }
+
+    private class MockFactory implements ConsumerFactory<String, byte[]> {
+
+        @Override
+        public Consumer<String, byte[]> createConsumer(String groupId) {
+            return consumer;
+        }
+    }
+}

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/SortedKafkaMessageBufferTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/SortedKafkaMessageBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.axonframework.extensions.kafka.eventhandling.consumer.streamable;
 
+import org.axonframework.extensions.kafka.eventhandling.consumer.FetchEventException;
 import org.junit.jupiter.api.*;
 
 import java.util.Collection;
@@ -42,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Tests for {@link SortedKafkaMessageBuffer}.
  *
- * @author Nakul Mishra.
+ * @author Nakul Mishra
+ * @author Gerard Klijs
  */
 public class SortedKafkaMessageBufferTest extends JSR166TestCase {
 
@@ -576,5 +578,31 @@ public class SortedKafkaMessageBufferTest extends JSR166TestCase {
             }
         });
         assertTrue(buffer.isEmpty());
+    }
+
+    public void testExceptionThrowOnTakeWhenSet() {
+        final SortedKafkaMessageBuffer<KafkaEventMessage> buff = new SortedKafkaMessageBuffer<>(SIZE);
+        buff.setException(new FetchEventException("something"));
+        assertThrows(FetchEventException.class, buff::take);
+    }
+
+    public void testExceptionThrowOnPeekWhenSet() {
+        final SortedKafkaMessageBuffer<KafkaEventMessage> buff = new SortedKafkaMessageBuffer<>(SIZE);
+        buff.setException(new FetchEventException("something"));
+        assertThrows(FetchEventException.class, buff::peek);
+    }
+
+    public void testExceptionThrowOnPollWhenSet() {
+        final SortedKafkaMessageBuffer<KafkaEventMessage> buff = new SortedKafkaMessageBuffer<>(SIZE);
+        buff.setException(new FetchEventException("something"));
+        assertThrows(FetchEventException.class, () -> buff.poll(10L, TimeUnit.SECONDS));
+    }
+
+    public void testOnceExceptionSetTakeStillFirstEmptiesBuffer() throws InterruptedException {
+        final SortedKafkaMessageBuffer<KafkaEventMessage> buff = new SortedKafkaMessageBuffer<>(SIZE);
+        buff.put(message(0, 1, 0, "m"));
+        buff.setException(new FetchEventException("something"));
+        buff.take();
+        assertThrows(FetchEventException.class, buff::take);
     }
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/streamable/StreamableKafkaMessageSourceTest.java
@@ -132,7 +132,7 @@ class StreamableKafkaMessageSourceTest {
     @Test
     void testOpeningMessageStreamWithNullTokenShouldInvokeFetcher() {
         AtomicBoolean closed = new AtomicBoolean(false);
-        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> {
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any())).thenReturn(() -> {
             closed.set(true);
             return true;
         });
@@ -140,7 +140,7 @@ class StreamableKafkaMessageSourceTest {
         BlockingStream<TrackedEventMessage<?>> result = testSubject.openStream(null);
 
         verify(consumerFactory).createConsumer(null);
-        verify(fetcher).poll(eq(mockConsumer), any(), any());
+        verify(fetcher).poll(eq(mockConsumer), any(), any(), any());
 
         result.close();
         assertTrue(closed.get());
@@ -149,7 +149,7 @@ class StreamableKafkaMessageSourceTest {
     @Test
     void testOpeningMessageStreamWithValidTokenShouldStartTheFetcher() {
         AtomicBoolean closed = new AtomicBoolean(false);
-        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> {
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any())).thenReturn(() -> {
             closed.set(true);
             return true;
         });
@@ -157,7 +157,7 @@ class StreamableKafkaMessageSourceTest {
         BlockingStream<TrackedEventMessage<?>> result = testSubject.openStream(emptyToken());
 
         verify(consumerFactory).createConsumer(null);
-        verify(fetcher).poll(eq(mockConsumer), any(), any());
+        verify(fetcher).poll(eq(mockConsumer), any(), any(), any());
 
         result.close();
         assertTrue(closed.get());

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSourceTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ class SubscribableKafkaMessageSourceTest {
 
     @Test
     void testAutoStartInitiatesProcessingOnFirstEventProcessor() {
-        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(NO_OP_FETCHER_REGISTRATION);
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any())).thenReturn(NO_OP_FETCHER_REGISTRATION);
 
         SubscribableKafkaMessageSource<String, String> testSubject =
                 SubscribableKafkaMessageSource.<String, String>builder()
@@ -142,13 +142,13 @@ class SubscribableKafkaMessageSourceTest {
 
         verify(consumerFactory, times(1)).createConsumer(DEFAULT_GROUP_ID);
         verify(mockConsumer, times(1)).subscribe(Collections.singletonList(TEST_TOPIC));
-        verify(fetcher).poll(eq(mockConsumer), any(), any());
+        verify(fetcher).poll(eq(mockConsumer), any(), any(), any());
     }
 
     @Test
     void testCancelingSubscribedEventProcessorRunsConnectedCloseHandlerWhenAutoStartIsOn() {
         AtomicBoolean closedFetcherRegistration = new AtomicBoolean(false);
-        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(() -> {
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any())).thenReturn(() -> {
             closedFetcherRegistration.set(true);
             return true;
         });
@@ -174,7 +174,7 @@ class SubscribableKafkaMessageSourceTest {
 
     @Test
     void testSubscribingTheSameInstanceTwiceDisregardsSecondInstanceOnStart() {
-        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(NO_OP_FETCHER_REGISTRATION);
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any())).thenReturn(NO_OP_FETCHER_REGISTRATION);
 
         testSubject.subscribe(NO_OP_EVENT_PROCESSOR);
         testSubject.subscribe(NO_OP_EVENT_PROCESSOR);
@@ -183,7 +183,7 @@ class SubscribableKafkaMessageSourceTest {
 
         verify(consumerFactory, times(1)).createConsumer(DEFAULT_GROUP_ID);
         verify(mockConsumer, times(1)).subscribe(Collections.singletonList(TEST_TOPIC));
-        verify(fetcher, times(1)).poll(eq(mockConsumer), any(), any());
+        verify(fetcher, times(1)).poll(eq(mockConsumer), any(), any(), any());
     }
 
     @Test
@@ -207,14 +207,14 @@ class SubscribableKafkaMessageSourceTest {
 
         verify(consumerFactory).createConsumer(DEFAULT_GROUP_ID);
         verify(mockConsumer).subscribe(testTopics);
-        verify(fetcher).poll(eq(mockConsumer), any(), any());
+        verify(fetcher).poll(eq(mockConsumer), any(), any(), any());
     }
 
     @Test
     void testStartBuildsConsumersUpToConsumerCount() {
         int expectedNumberOfConsumers = 2;
 
-        when(fetcher.poll(eq(mockConsumer), any(), any())).thenReturn(NO_OP_FETCHER_REGISTRATION);
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any())).thenReturn(NO_OP_FETCHER_REGISTRATION);
 
         SubscribableKafkaMessageSource<String, String> testSubject =
                 SubscribableKafkaMessageSource.<String, String>builder()
@@ -230,7 +230,7 @@ class SubscribableKafkaMessageSourceTest {
 
         verify(consumerFactory, times(expectedNumberOfConsumers)).createConsumer(DEFAULT_GROUP_ID);
         verify(mockConsumer, times(expectedNumberOfConsumers)).subscribe(Collections.singletonList(TEST_TOPIC));
-        verify(fetcher, times(expectedNumberOfConsumers)).poll(eq(mockConsumer), any(), any());
+        verify(fetcher, times(expectedNumberOfConsumers)).poll(eq(mockConsumer), any(), any(), any());
     }
 
     @Test
@@ -239,7 +239,7 @@ class SubscribableKafkaMessageSourceTest {
 
         AtomicBoolean closedEventProcessorOne = new AtomicBoolean(false);
         AtomicBoolean closedEventProcessorTwo = new AtomicBoolean(false);
-        when(fetcher.poll(eq(mockConsumer), any(), any()))
+        when(fetcher.poll(eq(mockConsumer), any(), any(), any()))
                 .thenReturn(() -> {
                     closedEventProcessorOne.set(true);
                     return true;
@@ -264,7 +264,7 @@ class SubscribableKafkaMessageSourceTest {
 
         verify(consumerFactory, times(expectedNumberOfConsumers)).createConsumer(DEFAULT_GROUP_ID);
         verify(mockConsumer, times(expectedNumberOfConsumers)).subscribe(Collections.singletonList(TEST_TOPIC));
-        verify(fetcher, times(expectedNumberOfConsumers)).poll(eq(mockConsumer), any(), any());
+        verify(fetcher, times(expectedNumberOfConsumers)).poll(eq(mockConsumer), any(), any(), any());
 
         assertTrue(closedEventProcessorOne.get());
         assertTrue(closedEventProcessorTwo.get());


### PR DESCRIPTION
With this change, exceptions while consuming from Kafka no longer are just logged but passed to the buffer. Once the buffer is empty, the exception will be thrown such that the processor will go into retry mode.

Fixes https://github.com/AxonFramework/extension-kafka/issues/276