### PR TITLE
Prepare for 4.6.0 release, also stop creating and deleting the same topics, which makes the tests more reliable.

### DIFF
--- a/kafka-spring-boot-autoconfigure/pom.xml
+++ b/kafka-spring-boot-autoconfigure/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -38,7 +38,6 @@ import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
 import org.axonframework.extensions.kafka.eventhandling.tokenstore.KafkaTokenStore;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
-import org.axonframework.spring.config.AxonConfiguration;
 import org.axonframework.springboot.autoconfig.AxonAutoConfiguration;
 import org.axonframework.springboot.autoconfig.InfraConfiguration;
 import org.slf4j.Logger;
@@ -92,12 +91,13 @@ public class KafkaAutoConfiguration {
     @ConditionalOnMissingBean
     public KafkaMessageConverter<String, byte[]> kafkaMessageConverter(
             @Qualifier("eventSerializer") Serializer eventSerializer,
-            AxonConfiguration config
+            org.axonframework.config.Configuration configuration
     ) {
         return DefaultKafkaMessageConverter
                 .builder()
                 .serializer(eventSerializer)
-                .upcasterChain(config.upcasterChain() != null ? config.upcasterChain() : new EventUpcasterChain())
+                .upcasterChain(configuration.upcasterChain()
+                                       != null ? configuration.upcasterChain() : new EventUpcasterChain())
                 .build();
     }
 
@@ -139,7 +139,7 @@ public class KafkaAutoConfiguration {
     public KafkaPublisher<String, byte[]> kafkaPublisher(
             ProducerFactory<String, byte[]> axonKafkaProducerFactory,
             KafkaMessageConverter<String, byte[]> kafkaMessageConverter,
-            AxonConfiguration configuration) {
+            org.axonframework.config.Configuration configuration) {
         return KafkaPublisher.<String, byte[]>builder()
                              .producerFactory(axonKafkaProducerFactory)
                              .messageConverter(kafkaMessageConverter)

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/SubscribingProducerIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/SubscribingProducerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-@TestPropertySource(properties = "axon.kafka.producer.event-processor-mode=SUBSCRIBING")
+@TestPropertySource("classpath:application-subscribing.properties")
 class SubscribingProducerIntegrationTest {
 
     @MockBean

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfigurationIntegrationTest.java
@@ -48,7 +48,6 @@ import org.axonframework.monitoring.NoOpMessageMonitor;
 import org.axonframework.serialization.Serializer;
 import org.axonframework.serialization.xml.CompactDriver;
 import org.axonframework.serialization.xml.XStreamSerializer;
-import org.axonframework.spring.config.AxonConfiguration;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -577,8 +576,8 @@ class KafkaAutoConfigurationIntegrationTest {
         }
 
         @Bean
-        public AxonConfiguration axonConfiguration() {
-            AxonConfiguration mock = mock(AxonConfiguration.class);
+        public org.axonframework.config.Configuration axonConfiguration() {
+            org.axonframework.config.Configuration mock = mock(org.axonframework.config.Configuration.class);
             //noinspection unchecked,rawtypes
             when(mock.messageMonitor(any(), any())).thenReturn((MessageMonitor) NoOpMessageMonitor.instance());
             return mock;

--- a/kafka-spring-boot-autoconfigure/src/test/resources/application-map-style.properties
+++ b/kafka-spring-boot-autoconfigure/src/test/resources/application-map-style.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010-2019. Axon Framework
+# Copyright (c) 2010-2022. Axon Framework
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,3 +29,4 @@ axon.kafka.consumer.properties.keyTwo=valueTwo
 axon.kafka.consumer.properties.keyThree=valueThree
 axon.kafka.consumer.properties.keyFour=valueFour
 axon.kafka.consumer.properties.keyFive=valueFive
+axon.axonserver.enabled=false

--- a/kafka-spring-boot-autoconfigure/src/test/resources/application-subscribing.properties
+++ b/kafka-spring-boot-autoconfigure/src/test/resources/application-subscribing.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2010-2022. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+axon.kafka.producer.event-processor-mode=SUBSCRIBING
+axon.axonserver.enabled=false

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <!-- Main -->
-        <axon.version>4.5.9</axon.version>
+        <axon.version>4.6.0-SNAPSHOT</axon.version>
         <kafka.version>3.2.0</kafka.version>
         <!-- Spring -->
         <spring.boot.version>2.7.0</spring.boot.version>


### PR DESCRIPTION
Update to SNAPSHOT version of framework:
- Use Lifecycle interface where applicable
- Override available segments method that was added earlier

Small optimalisation to integration test by no longer reuse same topics.