### PR TITLE
Remove KafkaPublisher as conditional, such that it's easier to use the autoconfig.

### DIFF
--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -70,7 +69,6 @@ import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEve
 @ConditionalOnExpression(
         "${axon.kafka.publisher.enabled:true} or ${axon.kafka.fetcher.enabled:true}"
 )
-@ConditionalOnClass(KafkaPublisher.class)
 @AutoConfigureAfter(AxonAutoConfiguration.class)
 @AutoConfigureBefore(InfraConfiguration.class)
 @EnableConfigurationProperties(KafkaProperties.class)


### PR DESCRIPTION
Fixes https://github.com/AxonFramework/extension-kafka/issues/306
seems like a legacy requirement that is no longer needed, and actually makes it harder to use the autoconfig in some cases.