### PR TITLE
Add Cloud event serializer

### DIFF
--- a/.run/Kafka Axon Example - PooledStreaming Producer and Consumer using Cloud Events.run.xml
+++ b/.run/Kafka Axon Example - PooledStreaming Producer and Consumer using Cloud Events.run.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2010-2022. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Kafka Axon Example - PooledStreaming Producer and Consumer using Cloud Events"
+                   type="JetRunConfigurationType" folderName="Kafka Axon Example">
+        <option name="MAIN_CLASS_NAME"
+                value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt"/>
+        <module name="kafka-axon-example"/>
+        <option name="PROGRAM_PARAMETERS"
+                value="--spring.profiles.active=pooled-streaming-producer,pooled-streaming-consumer,cloud-event"/>
+        <shortenClasspath name="NONE"/>
+        <method v="2">
+            <option name="Make" enabled="true"/>
+        </method>
+    </configuration>
+</component>

--- a/.run/Kafka Axon Example - PooledStreaming Producer and Consumer.run.xml
+++ b/.run/Kafka Axon Example - PooledStreaming Producer and Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - PooledStreaming Producer and Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+    <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=pooled-streaming-producer,pooled-streaming-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - PooledStreaming Producer and Subscribing Consumer.run.xml
+++ b/.run/Kafka Axon Example - PooledStreaming Producer and Subscribing Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - PooledStreaming Producer and Subscribing Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+    <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=pooled-streaming-producer,subscribing-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - PooledStreaming Producer and Tracking Consumer.run.xml
+++ b/.run/Kafka Axon Example - PooledStreaming Producer and Tracking Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - PooledStreaming Producer and Tracking Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+    <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=pooled-streaming-producer,tracking-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - Subscribing Producer and Consumer.run.xml
+++ b/.run/Kafka Axon Example - Subscribing Producer and Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - Subscribing Producer and Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+    <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=subscribing-producer,subscribing-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - Subscribing Producer and PooledStreaming Consumer.run.xml
+++ b/.run/Kafka Axon Example - Subscribing Producer and PooledStreaming Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - Subscribing Producer and PooledStreaming Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+    <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=subscribing-producer,pooled-streaming-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - Subscribing Producer and Tracking Consumer.run.xml
+++ b/.run/Kafka Axon Example - Subscribing Producer and Tracking Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - Subscribing Producer and Tracking Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+    <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=subscribing-producer,tracking-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - Tracking Producer and Consumer.run.xml
+++ b/.run/Kafka Axon Example - Tracking Producer and Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - Tracking Producer and Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+      <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=tracking-producer,tracking-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - Tracking Producer and PooledStreaming Consumer.run.xml
+++ b/.run/Kafka Axon Example - Tracking Producer and PooledStreaming Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - Tracking Producer and PooledStreaming Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+      <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=tracking-producer,pooled-streaming-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/.run/Kafka Axon Example - Tracking Producer and Subscribing Consumer.run.xml
+++ b/.run/Kafka Axon Example - Tracking Producer and Subscribing Consumer.run.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Kafka Axon Example - Tracking Producer and Subscribing Consumer" type="JetRunConfigurationType" folderName="Kafka Axon Example">
     <option name="MAIN_CLASS_NAME" value="org.axonframework.extensions.kafka.example.KafkaAxonExampleApplicationKt" />
-    <module name="axon-kafka-example" />
+      <module name="kafka-axon-example"/>
     <option name="PROGRAM_PARAMETERS" value="--spring.profiles.active=tracking-producer,subscribing-consumer" />
     <shortenClasspath name="NONE" />
     <method v="2">

--- a/kafka-axon-example/README.md
+++ b/kafka-axon-example/README.md
@@ -46,20 +46,21 @@ At this stage the following profiles can be used:
   * `cloud-events`
 
 If not specified, a `subscribing` producer and `tracking` consumer will be used.
-If `cloud-events` is not used, the format on the wire will be axon specific, using the
+If `cloud-events` is not used, the format on the wire will be Axon Framework specific, using the
 [DefaultKafkaMessageConverter.java](https://github.com/AxonFramework/extension-kafka/blob/master/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/DefaultKafkaMessageConverter.java)
 To activate these modes, please use Spring profiles in the run configuration like so:
 `--spring.profiles.active=tracking-producer,subscribing-consumer`
 
 ### Checking the format on the wire
 
-To check the format on the wire, including the headers you can get inside the kafka container with:
+To check the format on the wire, including the headers you can get inside the Kafka container with:
 
 ```bash
 docker exec -it kafka-axon-example_kafka_1 bash
 ```
 
-From the kafka bin folder, for example `/opt/kafka_2.13-2.8.1/bin` you can run:
+You can use the `kafka-console-consumer.sh` script located in the Kafka container. The folder is located in a path
+similar to `/opt/kafka_2.13-2.8.1/bin`. To consume all events from the default topic and also print the headers use:
 
 ```bash
 ./kafka-console-consumer.sh --topic Axon.Events --from-beginning --bootstrap-server localhost:9092 --property print.headers=true

--- a/kafka-axon-example/README.md
+++ b/kafka-axon-example/README.md
@@ -15,24 +15,26 @@ Please run:
 docker-compose -f ./kafka-axon-example/docker-compose.yaml up -d
 ```
 
-This will start [Zookeeper](https://zookeeper.apache.org/), [Kafka](https://github.com/wurstmeister/kafka-docker), 
- [KafkaCat](https://github.com/edenhill/kafkacat), [Kafka Rest](https://github.com/nodefluent/kafka-rest) and [Kafka Rest UI](https://github.com/nodefluent/kafka-rest-ui).
-KafkaCat can be used to investigate the setup, whereas the UI (accessed through localhost:8000, user `admin` and password `admin`) provides visualization of the internals.
+This will start [Zookeeper](https://zookeeper.apache.org/), [Kafka](https://github.com/wurstmeister/kafka-docker),
+[KafkaCat](https://github.com/edenhill/kafkacat), [Kafka Rest](https://github.com/nodefluent/kafka-rest)
+and [Kafka Rest UI](https://github.com/nodefluent/kafka-rest-ui).
+KafkaCat can be used to investigate the setup, whereas the UI (accessed through localhost:8000, user `admin` and
+password `admin`) provides visualization of the internals.
 
-Now build the application by running:
+If you use IntelliJ the run configuration from ./run can be used, otherwise build the application using:
 
 ```bash
 mvn clean package -f ./kafka-axon-example 
 ``` 
 
 ### Running example application
- 
-You can start the application by running `java -jar ./kafka-axon-example/target/axon-kafka-example.jar`.
 
-From a Kafka Message Source perspective, there are several options you have, as both consumption and production of 
+You can start the application by running `java -jar ./kafka-axon-example/target/kafka-axon-example.jar`.
+
+From a Kafka Message Source perspective, there are several options you have, as both consumption and production of
 event messages can be Subscribing or Streaming (aka push or pull).
 Thus, the application can run in six different modes due to the possibility to define a producer
- and consumer event processing mode.
+and consumer event processing mode.
 At this stage the following profiles can be used:
 
   * `subscribing-producer`
@@ -41,7 +43,24 @@ At this stage the following profiles can be used:
   * `subscribing-consumer`
   * `tracking-consumer`
   * `pooled-streaming-consumer`
- 
+  * `cloud-events`
+
 If not specified, a `subscribing` producer and `tracking` consumer will be used.
+If `cloud-events` is not used, the format on the wire will be axon specific, using the
+[DefaultKafkaMessageConverter.java](https://github.com/AxonFramework/extension-kafka/blob/master/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/DefaultKafkaMessageConverter.java)
 To activate these modes, please use Spring profiles in the run configuration like so:
- `--spring.profiles.active=tracking-producer,subscribing-consumer`
+`--spring.profiles.active=tracking-producer,subscribing-consumer`
+
+### Checking the format on the wire
+
+To check the format on the wire, including the headers you can get inside the kafka container with:
+
+```bash
+docker exec -it kafka-axon-example_kafka_1 bash
+```
+
+From the kafka bin folder, for example `/opt/kafka_2.13-2.8.1/bin` you can run:
+
+```bash
+./kafka-console-consumer.sh --topic Axon.Events --from-beginning --bootstrap-server localhost:9092 --property print.headers=true
+```

--- a/kafka-axon-example/pom.xml
+++ b/kafka-axon-example/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2021. Axon Framework
+  ~ Copyright (c) 2010-2022. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
         <version>4.6.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>axon-kafka-example</artifactId>
+    <artifactId>kafka-axon-example</artifactId>
     <version>4.6.0-SNAPSHOT</version>
 
     <name>Axon Framework Kafka Extension - Spring Boot Example</name>

--- a/kafka-axon-example/src/main/kotlin/org/axonframework/extensions/kafka/example/KafkaAxonExampleApplication.kt
+++ b/kafka-axon-example/src/main/kotlin/org/axonframework/extensions/kafka/example/KafkaAxonExampleApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2021. Axon Framework
+ * Copyright (c) 2010-2022. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,9 @@ import org.axonframework.extensions.kafka.eventhandling.consumer.ConsumerFactory
 import org.axonframework.extensions.kafka.eventhandling.consumer.Fetcher
 import org.axonframework.extensions.kafka.eventhandling.consumer.streamable.StreamableKafkaMessageSource
 import org.axonframework.extensions.kafka.eventhandling.consumer.subscribable.SubscribableKafkaMessageSource
-import org.axonframework.extensions.kafka.eventhandling.producer.ConfirmationMode
-import org.axonframework.extensions.kafka.eventhandling.producer.DefaultProducerFactory
-import org.axonframework.extensions.kafka.eventhandling.producer.ProducerFactory
+import org.axonframework.serialization.Serializer
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -70,18 +69,6 @@ class KafkaAxonExampleApplication {
      */
     @Bean
     fun tokenStore() = InMemoryTokenStore()
-
-    /**
-     * Creates a Kafka producer factory, using the Kafka properties configured in resources/application.yml
-     */
-    @Bean
-    fun producerFactory(kafkaProperties: KafkaProperties): ProducerFactory<String, ByteArray>? {
-        return DefaultProducerFactory.builder<String, ByteArray>()
-                .configuration(kafkaProperties.buildProducerProperties())
-                .producerCacheSize(10_000)
-                .confirmationMode(ConfirmationMode.WAIT_FOR_ACK)
-                .build()
-    }
 }
 
 /**
@@ -94,8 +81,10 @@ class KafkaAxonExampleApplication {
 class TrackingConfiguration {
 
     @Autowired
-    fun configureStreamableKafkaSource(configurer: EventProcessingConfigurer,
-                                       streamableKafkaMessageSource: StreamableKafkaMessageSource<String, ByteArray>) {
+    fun configureStreamableKafkaSource(
+        configurer: EventProcessingConfigurer,
+        streamableKafkaMessageSource: StreamableKafkaMessageSource<String, ByteArray>
+    ) {
         configurer.registerTrackingEventProcessor(KAFKA_GROUP) { streamableKafkaMessageSource }
     }
 }
@@ -107,25 +96,7 @@ class TrackingConfiguration {
  */
 @Configuration
 @ConditionalOnProperty(value = ["axon.kafka.consumer.event-processor-mode"], havingValue = "subscribing")
-class SubscribingConfiguration {
-
-    /**
-     * To start a [SubscribableKafkaMessageSource] at the right point in time, we should add those sources to a
-     * [KafkaMessageSourceConfigurer].
-     */
-    @Bean
-    fun kafkaMessageSourceConfigurer() = KafkaMessageSourceConfigurer()
-
-    /**
-     * The [KafkaMessageSourceConfigurer] should be added to Axon's [Configurer] to ensure it will be called upon start
-     * up.
-     */
-    @Suppress("SpringJavaInjectionPointsAutowiringInspection")
-    @Autowired
-    fun registerKafkaMessageSourceConfigurer(configurer: Configurer,
-                                             kafkaMessageSourceConfigurer: KafkaMessageSourceConfigurer) {
-        configurer.registerModule(kafkaMessageSourceConfigurer)
-    }
+class SubscribingBeans {
 
     /**
      * The autoconfiguration currently does not create a [SubscribableKafkaMessageSource] bean because the user is
@@ -138,27 +109,45 @@ class SubscribingConfiguration {
      */
     @Bean
     fun subscribableKafkaMessageSource(
-            kafkaProperties: KafkaProperties,
-            consumerFactory: ConsumerFactory<String, ByteArray>,
-            fetcher: Fetcher<String, ByteArray, EventMessage<*>>,
-            messageConverter: KafkaMessageConverter<String, ByteArray>,
-            kafkaMessageSourceConfigurer: KafkaMessageSourceConfigurer
+        @Qualifier("eventSerializer") eventSerializer: Serializer,
+        kafkaProperties: KafkaProperties,
+        consumerFactory: ConsumerFactory<String, ByteArray>,
+        fetcher: Fetcher<String, ByteArray, EventMessage<*>>,
+        messageConverter: KafkaMessageConverter<String, ByteArray>,
     ): SubscribableKafkaMessageSource<String, ByteArray> {
-        val subscribableKafkaMessageSource = SubscribableKafkaMessageSource.builder<String, ByteArray>()
+        return SubscribableKafkaMessageSource.builder<String, ByteArray>()
+            .serializer(eventSerializer)
             .topics(listOf(kafkaProperties.defaultTopic))
             .groupId(KAFKA_GROUP)
-                .consumerFactory(consumerFactory)
-                .fetcher(fetcher)
-                .messageConverter(messageConverter)
-                .build()
-        kafkaMessageSourceConfigurer.configureSubscribableSource { subscribableKafkaMessageSource }
-        return subscribableKafkaMessageSource
+            .consumerFactory(consumerFactory)
+            .fetcher(fetcher)
+            .messageConverter(messageConverter)
+            .build()
     }
 
+    @Bean
+    fun kafkaMessageSourceConfigurer(): KafkaMessageSourceConfigurer? {
+        return KafkaMessageSourceConfigurer()
+    }
+}
+
+/**
+ * If the Consumer Processor Mode is set to Subscribing, that's when we register a
+ * [org.axonframework.eventhandling.SubscribingEventProcessor] using the [SubscribableKafkaMessageSource]. We also need to use the [KafkaMessageSourceConfigurer] correctly to ensure the source starts and stops properly.
+ */
+@Configuration
+@ConditionalOnProperty(value = ["axon.kafka.consumer.event-processor-mode"], havingValue = "subscribing")
+class SubscribingConfiguration {
+
     @Autowired
-    fun configureSubscribableKafkaSource(eventProcessingConfigurer: EventProcessingConfigurer,
-                                         subscribableKafkaMessageSource: SubscribableKafkaMessageSource<String, ByteArray>) {
-        eventProcessingConfigurer.registerSubscribingEventProcessor(KAFKA_GROUP) { subscribableKafkaMessageSource }
+    fun configureSubscribableKafkaSource(
+        configurer: Configurer,
+        kafkaMessageSourceConfigurer: KafkaMessageSourceConfigurer,
+        subscribableKafkaMessageSource: SubscribableKafkaMessageSource<String, ByteArray>
+    ) {
+        kafkaMessageSourceConfigurer.configureSubscribableSource { subscribableKafkaMessageSource }
+        configurer.registerModule(kafkaMessageSourceConfigurer)
+        configurer.eventProcessing().registerSubscribingEventProcessor(KAFKA_GROUP) { subscribableKafkaMessageSource }
     }
 }
 
@@ -172,8 +161,10 @@ class SubscribingConfiguration {
 class PooledStreamingConfiguration {
 
     @Autowired
-    fun configureStreamableKafkaSource(configurer: EventProcessingConfigurer,
-                                       streamableKafkaMessageSource: StreamableKafkaMessageSource<String, ByteArray>) {
+    fun configureStreamableKafkaSource(
+        configurer: EventProcessingConfigurer,
+        streamableKafkaMessageSource: StreamableKafkaMessageSource<String, ByteArray>
+    ) {
         configurer.registerPooledStreamingEventProcessor(KAFKA_GROUP) { streamableKafkaMessageSource }
     }
 }

--- a/kafka-axon-example/src/main/resources/application-cloud-event.yml
+++ b/kafka-axon-example/src/main/resources/application-cloud-event.yml
@@ -1,0 +1,3 @@
+axon:
+  kafka:
+    message-converter-mode: cloud_event

--- a/kafka-axon-example/src/main/resources/application.yml
+++ b/kafka-axon-example/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
 axon:
   axonserver:
     enabled: false
+  serializer:
+    events: jackson
   kafka:
     clientid: kafka-axon-example
     producer:

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -89,6 +89,9 @@ public class KafkaProperties {
 
     private final Ssl ssl = new Ssl();
 
+    /**
+     * Converter mode to use, can be 'default' or 'cloud_event'.
+     */
     private MessageConverterMode messageConverterMode = MessageConverterMode.DEFAULT;
 
     public List<String> getBootstrapServers() {
@@ -768,13 +771,14 @@ public class KafkaProperties {
      */
     public enum MessageConverterMode {
         /**
-         * Default way using an 'axon' format, with data as binary value, and headers fo additional information, with
-         * most headers starting with 'axon-'.
+         * Default way using an 'axon' format, with data as binary value and headers for additional information, where
+         * most of the headers start with 'axon-'.
          */
         DEFAULT,
         /**
-         * Using Cloud Events, depending on the configuration of the serializers is either stored as one JSON with
-         * everything, or only the data as value with the metadata as headers, with all headers starting with 'ce_'.
+         * Using <a href="https://cloudevents.io/">Cloud Events</a>, depending on the configuration of the serializers
+         * is either stored as one JSON with everything, or only the data as value with all other information as
+         * headers, with all headers starting with 'ce_'.
          */
         CLOUD_EVENT
     }

--- a/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/SubscribingProducerIntegrationTest.java
+++ b/kafka-spring-boot-autoconfigure/src/test/java/org/axonframework/extensions/kafka/SubscribingProducerIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.*;
 class SubscribingProducerIntegrationTest {
 
     @MockBean
-    private KafkaPublisher<String, byte[]> kafkaPublisher;
+    private KafkaPublisher<?, ?> kafkaPublisher;
 
     @Autowired
     private EventBus eventBus;

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -36,6 +36,7 @@
         <test-containers.version>1.17.3</test-containers.version>
         <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <findbugs-jsr305.version>3.0.2</findbugs-jsr305.version>
+        <cloudevents.version>2.3.0</cloudevents.version>
     </properties>
 
     <packaging>jar</packaging>
@@ -56,6 +57,11 @@
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-kafka</artifactId>
+            <version>${cloudevents.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverter.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.cloudevent;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.v1.CloudEventBuilder;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventhandling.DomainEventMessage;
+import org.axonframework.eventhandling.EventData;
+import org.axonframework.eventhandling.EventMessage;
+import org.axonframework.eventhandling.GenericDomainEventEntry;
+import org.axonframework.eventhandling.GenericDomainEventMessage;
+import org.axonframework.eventhandling.GenericEventMessage;
+import org.axonframework.eventhandling.async.SequencingPolicy;
+import org.axonframework.eventhandling.async.SequentialPerAggregatePolicy;
+import org.axonframework.extensions.kafka.eventhandling.KafkaMessageConverter;
+import org.axonframework.messaging.MetaData;
+import org.axonframework.serialization.LazyDeserializingObject;
+import org.axonframework.serialization.SerializedMessage;
+import org.axonframework.serialization.SerializedObject;
+import org.axonframework.serialization.Serializer;
+import org.axonframework.serialization.upcasting.event.EventUpcasterChain;
+import org.axonframework.serialization.upcasting.event.InitialEventRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.axonframework.common.BuilderUtils.assertNonNull;
+import static org.axonframework.extensions.kafka.eventhandling.cloudevent.ExtensionUtils.*;
+
+/**
+ * Converts and {@link EventMessage} to a {@link ProducerRecord} Kafka message and from a {@link ConsumerRecord} Kafka
+ * message back to an EventMessage (if possible).
+ * <p>
+ * During conversion meta data entries with the {@code 'axon-metadata-'} prefix are passed to the {@link Headers}. Other
+ * message-specific attributes are added as metadata. The {@link EventMessage#getPayload()} is serialized using the
+ * configured {@link Serializer} and passed as the Kafka record's body.
+ * <p>
+ * <p>
+ * If an up-caster / up-caster chain is configured, this converter will pass the converted messages through it. Please
+ * note, that since the message converter consumes records one-by-one, the up-casting functionality is limited to
+ * one-to-one and one-to-many up-casters only.
+ * </p>
+ * This implementation will suffice in most cases.
+ *
+ * @author Gerard Klijs
+ * @since 4.6.0
+ */
+public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<String, CloudEvent> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CloudEventKafkaMessageConverter.class);
+
+    private final Serializer serializer;
+    private final SequencingPolicy<? super EventMessage<?>> sequencingPolicy;
+    private final EventUpcasterChain upcasterChain;
+
+    /**
+     * Instantiate a {@link CloudEventKafkaMessageConverter} based on the fields contained in the {@link Builder}.
+     * <p>
+     * Will assert that the {@link Serializer} is not {@code null} and will throw an {@link AxonConfigurationException}
+     * if it is {@code null}.
+     *
+     * @param builder the {@link Builder} used to instantiate a {@link CloudEventKafkaMessageConverter} instance
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected CloudEventKafkaMessageConverter(Builder builder) {
+        builder.validate();
+        this.serializer = builder.serializer;
+        this.sequencingPolicy = builder.sequencingPolicy;
+        this.upcasterChain = builder.upcasterChain;
+    }
+
+    /**
+     * Instantiate a Builder to be able to create a {@link CloudEventKafkaMessageConverter}.
+     * <p>
+     * The {@link SequencingPolicy} is defaulted to an {@link SequentialPerAggregatePolicy}. The {@link Serializer} is
+     * a
+     * <b>hard requirement</b> and as such should be provided.
+     *
+     * @return a Builder to be able to create a {@link CloudEventKafkaMessageConverter}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note that the {@link ProducerRecord} created through this method sets the {@link ProducerRecord#timestamp()} to
+     * {@code null}. Doing so will ensure the used Producer sets a timestamp itself for the record. The
+     * {@link EventMessage#getTimestamp()} field is however still taken into account, but as headers.
+     * <p>
+     * Additional note that the ProducerRecord will be given a {@code null} {@link ProducerRecord#partition()} value. In
+     * return, the {@link ProducerRecord#key()} field is defined by using the configured {@link SequencingPolicy} to
+     * retrieve the given {@code eventMessage}'s {@code sequenceIdentifier}. The combination of a {@code null} partition
+     * and the possibly present or empty key will define which partition the Producer will choose to dispatch the record
+     * on.
+     *
+     * @see ProducerRecord
+     */
+    @Override
+    public ProducerRecord<String, CloudEvent> createKafkaMessage(EventMessage<?> eventMessage, String topic) {
+        SerializedObject<byte[]> serializedObject = eventMessage.serializePayload(serializer, byte[].class);
+        return new ProducerRecord<>(
+                topic, null, null, recordKey(eventMessage),
+                toCloudEvent(eventMessage, serializedObject),
+                null
+        );
+    }
+
+    private CloudEvent toCloudEvent(EventMessage<?> message, SerializedObject<byte[]> serializedObject) {
+        CloudEventBuilder builder = new CloudEventBuilder();
+        builder.withId(message.getIdentifier());
+        builder.withData(serializedObject.getData());
+        builder.withSource(URI.create(message.getClass().getCanonicalName()));
+        builder.withType(serializedObject.getType().getName());
+        builder.withTime(message.getTimestamp().atOffset(ZoneOffset.UTC));
+        builder.withExtension(MESSAGE_REVISION, serializedObject.getType().getRevision());
+        if (message instanceof DomainEventMessage) {
+            DomainEventMessage<?> domainMessage = (DomainEventMessage<?>) message;
+            builder.withExtension(AGGREGATE_ID, domainMessage.getAggregateIdentifier());
+            builder.withExtension(AGGREGATE_SEQ, domainMessage.getSequenceNumber());
+            builder.withExtension(AGGREGATE_TYPE, domainMessage.getType());
+        }
+        message.getMetaData().entrySet().forEach(entry -> setExtension(builder, entry));
+        return builder.build();
+    }
+
+    private String recordKey(EventMessage<?> eventMessage) {
+        Object sequenceIdentifier = sequencingPolicy.getSequenceIdentifierFor(eventMessage);
+        return sequenceIdentifier != null ? sequenceIdentifier.toString() : null;
+    }
+
+    @Override
+    public Optional<EventMessage<?>> readKafkaMessage(ConsumerRecord<String, CloudEvent> consumerRecord) {
+        try {
+            CloudEvent cloudEvent = consumerRecord.value();
+            final EventData<?> eventData = createEventData(cloudEvent);
+            return upcasterChain
+                    .upcast(Stream.of(new InitialEventRepresentation(eventData, serializer)))
+                    .findFirst()
+                    .map(upcastedEventData -> new SerializedMessage<>(
+                                 upcastedEventData.getMessageIdentifier(),
+                                 new LazyDeserializingObject<>(upcastedEventData.getData(), serializer),
+                                 upcastedEventData.getMetaData()
+                         )
+                    ).flatMap(serializedMessage -> buildMessage(cloudEvent, serializedMessage));
+        } catch (Exception e) {
+            logger.trace("Error converting ConsumerRecord [{}] to an EventMessage", consumerRecord, e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Constructs event data representation from given Kafka headers and byte array body.
+     * <p>
+     * This method <i>reuses</i> the {@link GenericDomainEventEntry} class for both types of events which can be
+     * transmitted via Kafka. For domain events, the fields <code>aggregateType</code>, <code>aggregateId</code> and
+     * <code>aggregateSeq</code> will contain the corresponding values, but for the simple event they will be
+     * <code>null</code>. This is ok to pass <code>null</code> to those values and <code>0L</code> to
+     * <code>aggregateSeq</code>, since the {@link InitialEventRepresentation} does the same in its constructor and
+     * is implemented in a null-tolerant way. Check {@link CloudEventKafkaMessageConverter#isDomainEvent(CloudEvent)}
+     * for more details.
+     * </p>
+     *
+     * @param cloudEvent the event read from Kafka, serialized by the {@link io.cloudevents.kafka.CloudEventSerializer}
+     * @return event data.
+     */
+    private EventData<?> createEventData(CloudEvent cloudEvent) {
+        return new GenericDomainEventEntry<>(
+                asNullableString(cloudEvent.getExtension(AGGREGATE_TYPE)),
+                asNullableString(cloudEvent.getExtension(AGGREGATE_ID)),
+                asLong(cloudEvent.getExtension(AGGREGATE_SEQ)),
+                cloudEvent.getId(),
+                asOffsetDateTime(cloudEvent.getTime()),
+                cloudEvent.getType(),
+                asNullableString(cloudEvent.getExtension(MESSAGE_REVISION)),
+                asBytes(cloudEvent.getData()),
+                extractMetadataAsBytes(cloudEvent)
+        );
+    }
+
+    private byte[] extractMetadataAsBytes(CloudEvent cloudEvent) {
+        Map<String, Object> metadataMap = new HashMap<>();
+        cloudEvent.getExtensionNames().forEach(name -> {
+            if (!isNonMetadataExtension(name)) {
+                metadataMap.put(name, cloudEvent.getExtension(name));
+            }
+        });
+        return serializer.serialize(MetaData.from(metadataMap), byte[].class).getData();
+    }
+
+    /**
+     * Checks if the event is originated from an aggregate (domain event) or is a simple event sent over the bus.
+     * <p>
+     * The difference between a DomainEventMessage and an EventMessage, is the following three fields:
+     * <ul>
+     *     <li>The type - represents the Aggregate the event originates from. It would be empty for an EventMessage and
+     *     filled for a DomainEventMessage.</li>
+     *     <li>The aggregateIdentifier - represents the Aggregate instance the event originates from. It would be equal
+     *     to the eventIdentifier for an EventMessage and not equal to that identifier a DomainEventMessage.</li>
+     *     <li>The sequenceNumber - represents the order of the events within an Aggregate instance's event stream.
+     *     It would be 0 at all times for an EventMessage, whereas a DomainEventMessage would be 0 or greater.</li>
+     * </ul>
+     * </p>
+     *
+     * @param cloudEvent Cloud Event
+     * @return <code>true</code> if the event is originated from an aggregate.
+     */
+    private static boolean isDomainEvent(CloudEvent cloudEvent) {
+        return cloudEvent.getExtension(AGGREGATE_TYPE) != null
+                && cloudEvent.getExtension(AGGREGATE_ID) != null
+                && cloudEvent.getExtension(AGGREGATE_SEQ) != null;
+    }
+
+    private static Optional<EventMessage<?>> buildMessage(CloudEvent cloudEvent, SerializedMessage<?> message) {
+        Instant timestamp = Instant.from(asOffsetDateTime(cloudEvent.getTime()));
+        return isDomainEvent(cloudEvent)
+                ? buildDomainEventMessage(cloudEvent, message, timestamp)
+                : buildEventMessage(message, timestamp);
+    }
+
+    private static Optional<EventMessage<?>> buildDomainEventMessage(CloudEvent cloudEvent,
+                                                                     SerializedMessage<?> message,
+                                                                     Instant timestamp) {
+        return Optional.of(new GenericDomainEventMessage<>(
+                asNullableString(cloudEvent.getExtension(AGGREGATE_TYPE)),
+                asNullableString(cloudEvent.getExtension(AGGREGATE_ID)),
+                asLong(cloudEvent.getExtension(AGGREGATE_SEQ)),
+                message,
+                () -> timestamp
+        ));
+    }
+
+    private static Optional<EventMessage<?>> buildEventMessage(SerializedMessage<?> message, Instant timestamp) {
+        return Optional.of(new GenericEventMessage<>(message, () -> timestamp));
+    }
+
+    /**
+     * Builder class to instantiate a {@link CloudEventKafkaMessageConverter}.
+     * <p>
+     * The {@link SequencingPolicy} is defaulted to an {@link SequentialPerAggregatePolicy}. The {@link Serializer} is
+     * a
+     * <b>hard requirement</b> and as such should be provided.
+     */
+    public static class Builder {
+
+        private Serializer serializer;
+        private SequencingPolicy<? super EventMessage<?>> sequencingPolicy = SequentialPerAggregatePolicy.instance();
+        private EventUpcasterChain upcasterChain = new EventUpcasterChain();
+
+        /**
+         * Sets the serializer to serialize the Event Message's payload with.
+         *
+         * @param serializer The serializer to serialize the Event Message's payload with
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder serializer(Serializer serializer) {
+            assertNonNull(serializer, "Serializer may not be null");
+            this.serializer = serializer;
+            return this;
+        }
+
+        /**
+         * Sets the {@link SequencingPolicy}, with a generic of being a super of {@link EventMessage}, used to generate
+         * the key for the {@link ProducerRecord}. Defaults to a {@link SequentialPerAggregatePolicy} instance.
+         *
+         * @param sequencingPolicy a {@link SequencingPolicy} used to generate the key for the {@link ProducerRecord}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder sequencingPolicy(SequencingPolicy<? super EventMessage<?>> sequencingPolicy) {
+            assertNonNull(sequencingPolicy, "SequencingPolicy may not be null");
+            this.sequencingPolicy = sequencingPolicy;
+            return this;
+        }
+
+        /**
+         * Sets the {@code upcasterChain} to be used during the consumption of events.
+         *
+         * @param upcasterChain upcaster chain to be used on event reading.
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder upcasterChain(EventUpcasterChain upcasterChain) {
+            assertNonNull(upcasterChain, "UpcasterChain must not be null");
+            this.upcasterChain = upcasterChain;
+            return this;
+        }
+
+        /**
+         * Initializes a {@link CloudEventKafkaMessageConverter} as specified through this Builder.
+         *
+         * @return a {@link CloudEventKafkaMessageConverter} as specified through this Builder
+         */
+        public CloudEventKafkaMessageConverter build() {
+            return new CloudEventKafkaMessageConverter(this);
+        }
+
+        /**
+         * Validates whether the fields contained in this Builder are set accordingly.
+         *
+         * @throws AxonConfigurationException if one field is asserted to be incorrect according to the Builder's
+         *                                    specifications
+         */
+        @SuppressWarnings("WeakerAccess")
+        protected void validate() throws AxonConfigurationException {
+            assertNonNull(serializer, "The Serializer is a hard requirement and should be provided");
+        }
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverter.java
@@ -60,7 +60,7 @@ import static org.axonframework.extensions.kafka.eventhandling.cloudevent.Metada
  * <p>
  * During conversion, metadata entries are stored as extensions. This might require adding mappings with either
  * {@link Builder#addMetadataMapper(String, String)} or {@link Builder#addMetadataMappers(Map)}. For the {@code source}
- * field, we default to the class of the message. You can set the
+ * field, we default to <a href="https://www.axoniq.io/">https://www.axoniq.io/</a>. You can set the
  * {@link Builder#sourceSupplier(Function) sourceSupplier} to change this. For the {@code subject} field, we default to
  * setting it from the metadata. You can set the {@link Builder#subjectSupplier(Function) subjectSupplier} to change
  * this. For the {@code dataContentType} field, we default to setting it from the metadata. You can set the
@@ -102,7 +102,7 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
      * The {@code upcasterChain} is defaulted to a new {@link EventUpcasterChain}. During conversion, metadata entries
      * are stored as extensions. This might require adding mappings with either
      * {@link Builder#addMetadataMapper(String, String)} or {@link Builder#addMetadataMappers(Map)}. For the
-     * {@code source} field, we default to the class of the message. You can set the
+     * {@code source} field, we default to <a href="https://www.axoniq.io/">https://www.axoniq.io/</a>. You can set the
      * {@link Builder#sourceSupplier(Function) sourceSupplier} to change this. For the {@code subject} field, we default
      * to setting it from the metadata. You can set the {@link Builder#subjectSupplier(Function) subjectSupplier} to
      * change this. For the {@code dataContentType} field, we default to setting it from the metadata. You can set the
@@ -132,8 +132,8 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
     /**
      * Instantiate a Builder to be able to create a {@link CloudEventKafkaMessageConverter}.
      * <p>
-     * The {@link SequencingPolicy} is defaulted to an {@link SequentialPerAggregatePolicy}. The {@link Serializer} is
-     * a <b>hard requirement</b> and as such should be provided.
+     * The {@link SequencingPolicy} is defaulted to an {@link SequentialPerAggregatePolicy}. The {@link Serializer} is a
+     * <b>hard requirement</b> and as such should be provided.
      *
      * @return a Builder to be able to create a {@link CloudEventKafkaMessageConverter}
      */
@@ -310,7 +310,7 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
         private SequencingPolicy<? super EventMessage<?>> sequencingPolicy = SequentialPerAggregatePolicy.instance();
         private EventUpcasterChain upcasterChain = new EventUpcasterChain();
         private final Map<String, String> metadataToExtensionMap = tracingMap();
-        private Function<EventMessage<?>, URI> sourceSupplier = m -> URI.create(m.getClass().getCanonicalName());
+        private Function<EventMessage<?>, URI> sourceSupplier = m -> URI.create("https://www.axoniq.io/");
         private Function<EventMessage<?>, Optional<String>> subjectSupplier = defaultSubjectSupplier();
         private Function<EventMessage<?>, Optional<String>> dataContentTypeSupplier = defaultDataContentTypeSupplier();
         private Function<EventMessage<?>, Optional<URI>> dataSchemaSupplier = defaultDataSchemaSupplier();
@@ -398,8 +398,8 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
         }
 
         /**
-         * Sets the {@code sourceSupplier} to be used to determine the source of the Cloud Event, this defaults to the
-         * full classpath of the message.
+         * Sets the {@code sourceSupplier} to be used to determine the source of the Cloud Event, this defaults to <a
+         * href="https://www.axoniq.io/">https://www.axoniq.io/</a>.
          *
          * @param sourceSupplier the supplier of the source
          * @return the current Builder instance, for fluent interfacing

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverter.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverter.java
@@ -62,7 +62,10 @@ import static org.axonframework.extensions.kafka.eventhandling.cloudevent.Extens
  * During conversion metadata entries are stored as extensions This might require adding mappings with either
  * {@link Builder#addMetadataMapper(String, String)} or {@link Builder#addMetadataMappers(Map)}. For the 'source' field
  * we default to the class of the message. You can set the {@link Builder#sourceSupplier(Function) sourceSupplier} to
- * change this. Other message-specific attributes are mapped to those best matching Cloud Events. The
+ * change this. For the 'dataContentType' field we default to none. You can set the
+ * {@link Builder#dataContentTypeSupplier(Function) dataContentTypeSupplier} to change this. For the 'dataSchema' field
+ * we default to none. You can set the {@link Builder#dataSchemaSupplier(Function)  dataSchemaSupplier} to change this.
+ * Other message-specific attributes are mapped to those best matching Cloud Events. The
  * {@link EventMessage#getPayload()} is serialized using the configured {@link Serializer} and passed as bytearray to
  * the Cloud Event data field.
  * <p>
@@ -85,6 +88,8 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
     private final Map<String, String> extensionNameResolver;
     private final Map<String, String> metadataNameResolver;
     private final Function<EventMessage<?>, URI> sourceSupplier;
+    private final Function<EventMessage<?>, Optional<String>> dataContentTypeSupplier;
+    private final Function<EventMessage<?>, Optional<URI>> dataSchemaSupplier;
 
     /**
      * Instantiate a {@link CloudEventKafkaMessageConverter} based on the fields contained in the {@link Builder}.
@@ -106,6 +111,8 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
                                                                   .collect(Collectors.toMap(Map.Entry::getValue,
                                                                                             Map.Entry::getKey));
         this.sourceSupplier = builder.sourceSupplier;
+        this.dataContentTypeSupplier = builder.dataContentTypeSupplier;
+        this.dataSchemaSupplier = builder.dataSchemaSupplier;
     }
 
     /**
@@ -150,6 +157,8 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
         CloudEventBuilder builder = new CloudEventBuilder();
         builder.withId(message.getIdentifier());
         builder.withData(serializedObject.getData());
+        dataContentTypeSupplier.apply(message).ifPresent(builder::withDataContentType);
+        dataSchemaSupplier.apply(message).ifPresent(builder::withDataSchema);
         builder.withSource(sourceSupplier.apply(message));
         builder.withType(serializedObject.getType().getName());
         builder.withTime(message.getTimestamp().atOffset(ZoneOffset.UTC));
@@ -310,6 +319,8 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
         private EventUpcasterChain upcasterChain = new EventUpcasterChain();
         private final Map<String, String> metadataToExtensionMap = tracingMap();
         private Function<EventMessage<?>, URI> sourceSupplier = m -> URI.create(m.getClass().getCanonicalName());
+        private Function<EventMessage<?>, Optional<String>> dataContentTypeSupplier = m -> Optional.empty();
+        private Function<EventMessage<?>, Optional<URI>> dataSchemaSupplier = m -> Optional.empty();
 
         /**
          * Creates a new map, to convert the two metadata properties used for tracing, which are incompatible with cloud
@@ -398,8 +409,34 @@ public class CloudEventKafkaMessageConverter implements KafkaMessageConverter<St
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder sourceSupplier(Function<EventMessage<?>, URI> sourceSupplier) {
-            assertNonNull(upcasterChain, "sourceSupplier must not be null");
+            assertNonNull(sourceSupplier, "sourceSupplier must not be null");
             this.sourceSupplier = sourceSupplier;
+            return this;
+        }
+
+        /**
+         * Sets the {@code dataContentTypeSupplier} to be used to determine the data content type of the Cloud Event,
+         * this defaults to none.
+         *
+         * @param dataContentTypeSupplier the supplier of the data content type
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder dataContentTypeSupplier(Function<EventMessage<?>, Optional<String>> dataContentTypeSupplier) {
+            assertNonNull(dataContentTypeSupplier, "dataContentTypeSupplier must not be null");
+            this.dataContentTypeSupplier = dataContentTypeSupplier;
+            return this;
+        }
+
+        /**
+         * Sets the {@code dataContentTypeSupplier} to be used to determine the data content type of the Cloud Event,
+         * this defaults to none.
+         *
+         * @param dataSchemaSupplier the supplier of the data schema
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder dataSchemaSupplier(Function<EventMessage<?>, Optional<URI>> dataSchemaSupplier) {
+            assertNonNull(dataSchemaSupplier, "dataSchemaSupplier must not be null");
+            this.dataSchemaSupplier = dataSchemaSupplier;
             return this;
         }
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/ExtensionUtils.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/ExtensionUtils.java
@@ -46,26 +46,26 @@ import static org.axonframework.extensions.kafka.eventhandling.cloudevent.Metada
  * @author Gerard Klijs
  * @since 4.6.0
  */
-class ExtensionUtils {
+public class ExtensionUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(ExtensionUtils.class);
 
     /**
      * Extension name pointing to the revision of a message.
      */
-    static final String MESSAGE_REVISION = "axonmessagerevision";
+    public static final String MESSAGE_REVISION = "axonmessagerevision";
     /**
      * Extension name pointing to the aggregate identifier of a message.
      */
-    static final String AGGREGATE_ID = "axonmessageaggregateid";
+    public static final String AGGREGATE_ID = "axonmessageaggregateid";
     /**
      * Extension name pointing to the aggregate sequence of a message.
      */
-    static final String AGGREGATE_SEQ = "axonmessageaggregateseq";
+    public static final String AGGREGATE_SEQ = "axonmessageaggregateseq";
     /**
      * Extension name pointing to the aggregate type of a message.
      */
-    static final String AGGREGATE_TYPE = "axonmessageaggregatetype";
+    public static final String AGGREGATE_TYPE = "axonmessageaggregatetype";
 
     private static final Set<String> NON_METADATA_EXTENSIONS = Stream
             .of(AGGREGATE_TYPE, AGGREGATE_ID, AGGREGATE_SEQ, MESSAGE_REVISION)
@@ -75,7 +75,17 @@ class ExtensionUtils {
         // Utility class
     }
 
-    static void setExtensions(
+    /**
+     * Adds extension values to the {@link CloudEvent} based on the {@link EventMessage} and {@link SerializedObject}
+     * using the {@code extensionNameResolver} map to resolve the extension names.
+     *
+     * @param builder               a {@link CloudEventBuilder} to add the values to
+     * @param message               an {@link EventMessage} that might contain information that needs to be added as
+     *                              extension
+     * @param serializedObject      a {@link SerializedObject} that might contain a revision
+     * @param extensionNameResolver a {@link Map} used to convert metadata keys to extension names
+     */
+    public static void setExtensions(
             CloudEventBuilder builder,
             EventMessage<?> message,
             SerializedObject<byte[]> serializedObject,
@@ -98,7 +108,14 @@ class ExtensionUtils {
                                               entry.getValue()));
     }
 
-    static MetaData getExtensionsAsMetadata(CloudEvent cloudEvent, Map<String, String> metadataNameResolver) {
+    /**
+     * Will return extensions of the {@link CloudEvent} as {@link MetaData}.
+     *
+     * @param cloudEvent           the {@link CloudEvent} to extract the extensions of
+     * @param metadataNameResolver a {@link Map} used to convert extension names to metadata keys
+     * @return the {@link MetaData} containing the extension keys and values
+     */
+    public static MetaData getExtensionsAsMetadata(CloudEvent cloudEvent, Map<String, String> metadataNameResolver) {
         Map<String, Object> metadataMap = new HashMap<>();
         cloudEvent.getExtensionNames().forEach(name -> {
             if (!isNonMetadataExtension(name)) {
@@ -124,11 +141,11 @@ class ExtensionUtils {
         return metadataKey;
     }
 
-    static boolean isNonMetadataExtension(String extensionName) {
+    private static boolean isNonMetadataExtension(String extensionName) {
         return NON_METADATA_EXTENSIONS.contains(extensionName);
     }
 
-    static void setExtension(CloudEventBuilder builder, String extensionName, Object value) {
+    private static void setExtension(CloudEventBuilder builder, String extensionName, Object value) {
         if (isNonMetadataExtension(extensionName)) {
             throw new InvalidMetaDataException(
                     String.format("Metadata property '%s' is already reserved to be used for Axon",
@@ -163,7 +180,13 @@ class ExtensionUtils {
         }
     }
 
-    static String asNullableString(Object object) {
+    /**
+     * Will return the {@link Object} as {@link String} if it's a {@link String}, otherwise {@code null} is returned.
+     *
+     * @param object a value, which is likely to be a {@link String}
+     * @return the object as {@link String} or {@code null}
+     */
+    public static String asNullableString(Object object) {
         if (object instanceof String) {
             return (String) object;
         } else {
@@ -171,7 +194,13 @@ class ExtensionUtils {
         }
     }
 
-    static Long asLong(Object object) {
+    /**
+     * Will return the {@link Object} as {@link Long} if it's a {@link Long}, otherwise {@code 0L} is returned.
+     *
+     * @param object a value, which is likely to be a {@link Long}
+     * @return the object as {@link Long} or the default value, {@code 0L}
+     */
+    public static Long asLong(Object object) {
         if (object instanceof Long) {
             return (Long) object;
         } else {
@@ -179,7 +208,16 @@ class ExtensionUtils {
         }
     }
 
-    static OffsetDateTime asOffsetDateTime(Object object, long fallbackTimestamp) {
+    /**
+     * Will return the {@link Object} as {@link OffsetDateTime} if it's a {@link OffsetDateTime}, otherwise
+     * {@code fallbackTimestamp} is returned.
+     *
+     * @param object            a value, which is likely to be a {@link OffsetDateTime}
+     * @param fallbackTimestamp a fallback value as long, in case the {@code object} is {@code null}
+     * @return the object as {@link OffsetDateTime} or the fallback timestamp as {@link OffsetDateTime} at offset
+     * {@link ZoneOffset#UTC}
+     */
+    public static OffsetDateTime asOffsetDateTime(Object object, long fallbackTimestamp) {
         if (object instanceof OffsetDateTime) {
             return (OffsetDateTime) object;
         } else {
@@ -187,7 +225,14 @@ class ExtensionUtils {
         }
     }
 
-    static byte[] asBytes(CloudEventData data) {
+    /**
+     * Will return the {@link CloudEventData} as {@code byte[]} if it's not {@code null}, otherwise an empty array is
+     * returned.
+     *
+     * @param data {@link CloudEventData}, which might be {@code null}
+     * @return the data as byte array, or an empty byte array if the data was {@code null}
+     */
+    public static byte[] asBytes(CloudEventData data) {
         if (isNull(data)) {
             return new byte[0];
         } else {
@@ -195,13 +240,20 @@ class ExtensionUtils {
         }
     }
 
-    static boolean isValidExtensionName(String name) {
+    /**
+     * Tests whether the name is valid according to the cloud events <a
+     * href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#naming-conventions">attribute naming
+     * conventions</a>.
+     *
+     * @param name the {@link String} to validate
+     * @return {@code true} if the given {@code name} is valid and {@code false} if it isn't
+     */
+    public static boolean isValidExtensionName(String name) {
         for (int i = 0; i < name.length(); ++i) {
             if (!isValidChar(name.charAt(i))) {
                 return false;
             }
         }
-
         return true;
     }
 
@@ -209,7 +261,15 @@ class ExtensionUtils {
         return c >= 'a' && c <= 'z' || c >= '0' && c <= '9';
     }
 
-    static boolean isValidMetadataToExtensionMap(Map<String, String> metadataToExtensionMap) {
+    /**
+     * Tests whether all the values of the {@code metadataToExtensionMap} are valid according to the cloud events <a
+     * href="https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#naming-conventions">attribute naming
+     * conventions</a>.
+     *
+     * @param metadataToExtensionMap the {@link Map} to validate
+     * @return {@code true} if the given {@code metadataToExtensionMap} is valid and {@code false} if it isn't
+     */
+    public static boolean isValidMetadataToExtensionMap(Map<String, String> metadataToExtensionMap) {
         for (String extensionName : metadataToExtensionMap.values()) {
             if (!isValidExtensionName(extensionName)) {
                 return false;

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/ExtensionUtils.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/ExtensionUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.cloudevent;
+
+import io.cloudevents.CloudEventData;
+import io.cloudevents.core.v1.CloudEventBuilder;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Utility class for dealing with cloud event extension, to store and retrieve data.
+ *
+ * @author Gerard Klijs
+ * @since 4.6.0
+ */
+class ExtensionUtils {
+
+    /**
+     * Extension name pointing to the revision of a message.
+     */
+    static final String MESSAGE_REVISION = "axonmessagerevision";
+    /**
+     * Extension name pointing to the aggregate identifier of a message.
+     */
+    static final String AGGREGATE_ID = "axonmessageaggregateid";
+    /**
+     * Extension name pointing to the aggregate sequence of a message.
+     */
+    static final String AGGREGATE_SEQ = "axonmessageaggregateseq";
+    /**
+     * Extension name pointing to the aggregate type of a message.
+     */
+    static final String AGGREGATE_TYPE = "axonmessageaggregatetype";
+
+    private static final Set<String> NON_METADATA_EXTENSIONS = Stream
+            .of(AGGREGATE_TYPE, AGGREGATE_ID, AGGREGATE_SEQ, MESSAGE_REVISION)
+            .collect(Collectors.toCollection(HashSet::new));
+
+    private ExtensionUtils() {
+        // Utility class
+    }
+
+    static boolean isNonMetadataExtension(String extensionName) {
+        return NON_METADATA_EXTENSIONS.contains(extensionName);
+    }
+
+    static void setExtension(CloudEventBuilder builder, Map.Entry<String, Object> entry) {
+        if (isNonMetadataExtension(entry.getKey())) {
+            throw new InvalidMetaDataException(
+                    String.format("Metadata property '%s' is already reserved to be used for Axon",
+                                  entry.getKey())
+            );
+        }
+        if (entry.getValue() instanceof String) {
+            builder.withExtension(entry.getKey(), (String) entry.getValue());
+        } else if (entry.getValue() instanceof Number) {
+            builder.withExtension(entry.getKey(), (Number) entry.getValue());
+        } else if (entry.getValue() instanceof Boolean) {
+            builder.withExtension(entry.getKey(), (Boolean) entry.getValue());
+        } else if (entry.getValue() instanceof URI) {
+            builder.withExtension(entry.getKey(), (URI) entry.getValue());
+        } else if (entry.getValue() instanceof OffsetDateTime) {
+            builder.withExtension(entry.getKey(), (OffsetDateTime) entry.getValue());
+        } else if (entry.getValue() instanceof byte[]) {
+            builder.withExtension(entry.getKey(), (byte[]) entry.getValue());
+        } else {
+            throw new InvalidMetaDataException(
+                    String.format("Metadata property '%s' is of class '%s' and thus can't be added",
+                                  entry.getKey(),
+                                  entry.getValue().getClass())
+            );
+        }
+    }
+
+    static String asNullableString(Object object) {
+        if (object instanceof String) {
+            return (String) object;
+        } else {
+            return null;
+        }
+    }
+
+    static Long asLong(Object object) {
+        if (object instanceof Long) {
+            return (Long) object;
+        } else {
+            return 0L;
+        }
+    }
+
+    static OffsetDateTime asOffsetDateTime(Object object) {
+        if (object instanceof OffsetDateTime) {
+            return (OffsetDateTime) object;
+        } else {
+            return Instant.now().atOffset(ZoneOffset.UTC);
+        }
+    }
+
+    static byte[] asBytes(CloudEventData data) {
+        if (isNull(data)) {
+            return new byte[0];
+        } else {
+            return data.toBytes();
+        }
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/ExtensionUtils.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/ExtensionUtils.java
@@ -155,7 +155,8 @@ class ExtensionUtils {
             builder.withExtension(extensionName, (byte[]) value);
         } else {
             throw new InvalidMetaDataException(
-                    String.format("Metadata property '%s' is of class '%s' and thus can't be added",
+                    String.format("Metadata property '%s' is of class '%s' and thus can't be added.\n"
+                                          + "Supported classes are String, Number, Boolean, URI, OffsetDataTime and byte[]",
                                   extensionName,
                                   value.getClass())
             );

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/InvalidMetaDataException.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/InvalidMetaDataException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.cloudevent;
+
+import org.axonframework.common.AxonException;
+
+/**
+ * Exception thrown when failing to add metadata to a cloud event.
+ *
+ * @author Gerard Klijs
+ * @since 4.6.0
+ */
+public class InvalidMetaDataException extends AxonException {
+
+    /**
+     * Initializes the exception using the given {@code message}.
+     *
+     * @param message The message describing the exception
+     */
+    public InvalidMetaDataException(String message) {
+        super(message);
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/InvalidMetaDataException.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/InvalidMetaDataException.java
@@ -29,7 +29,7 @@ public class InvalidMetaDataException extends AxonException {
     /**
      * Initializes the exception using the given {@code message}.
      *
-     * @param message The message describing the exception
+     * @param message The message describing the exception.
      */
     public InvalidMetaDataException(String message) {
         super(message);

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/MetadataUtils.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/MetadataUtils.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2022. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extensions.kafka.eventhandling.cloudevent;
+
+import io.cloudevents.CloudEvent;
+import org.axonframework.eventhandling.EventMessage;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Objects.isNull;
+
+/**
+ * Utility class for dealing with cloud events conversion, to store and retrieve data from/to Metadata.
+ *
+ * @author Gerard Klijs
+ * @since 4.6.0
+ */
+public class MetadataUtils {
+
+    /**
+     * Metadata key to store the subject.
+     */
+    static final String SUBJECT = "cloud-event-subject";
+    /**
+     * Metadata key to store the data content type.
+     */
+    static final String DATA_CONTENT_TYPE = "cloud-event-data-content-type";
+    /**
+     * Metadata key to store the data schema.
+     */
+    static final String DATA_SCHEMA = "cloud-event-data-schema";
+    private static final Set<String> RESERVED_METADATA = Stream
+            .of(SUBJECT, DATA_CONTENT_TYPE, DATA_SCHEMA)
+            .collect(Collectors.toCollection(HashSet::new));
+
+    private MetadataUtils() {
+        // Utility class
+    }
+
+    static Predicate<Map.Entry<String, Object>> reservedMetadataFilter() {
+        return e -> !RESERVED_METADATA.contains(e.getKey());
+    }
+
+    static Map<String, Object> getAdditionalEntries(CloudEvent cloudEvent) {
+        Map<String, Object> metadataMap = new HashMap<>();
+        if (!isNull(cloudEvent.getSubject())) {
+            metadataMap.put(SUBJECT, cloudEvent.getSubject());
+        }
+        if (!isNull(cloudEvent.getDataContentType())) {
+            metadataMap.put(DATA_CONTENT_TYPE, cloudEvent.getDataContentType());
+        }
+        if (!isNull(cloudEvent.getDataSchema())) {
+            metadataMap.put(DATA_SCHEMA, cloudEvent.getDataSchema());
+        }
+        return metadataMap;
+    }
+
+    @SuppressWarnings("squid:S1452") //needs wildcard to be generic
+    static Function<EventMessage<?>, Optional<String>> defaultSubjectSupplier() {
+        return message -> {
+            Object subject = message.getMetaData().get(SUBJECT);
+            if (subject instanceof String) {
+                return Optional.of((String) subject);
+            } else {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @SuppressWarnings("squid:S1452") //needs wildcard to be generic
+    static Function<EventMessage<?>, Optional<String>> defaultDataContentTypeSupplier() {
+        return message -> {
+            Object dataContentType = message.getMetaData().get(DATA_CONTENT_TYPE);
+            if (dataContentType instanceof String) {
+                return Optional.of((String) dataContentType);
+            } else {
+                return Optional.empty();
+            }
+        };
+    }
+
+    @SuppressWarnings("squid:S1452") //needs wildcard to be generic
+    static Function<EventMessage<?>, Optional<URI>> defaultDataSchemaSupplier() {
+        return message -> {
+            Object dataSchema = message.getMetaData().get(DATA_SCHEMA);
+            if (dataSchema instanceof URI) {
+                return Optional.of((URI) dataSchema);
+            } else {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/MetadataUtils.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/MetadataUtils.java
@@ -43,15 +43,15 @@ public class MetadataUtils {
     /**
      * Metadata key to store the subject.
      */
-    static final String SUBJECT = "cloud-event-subject";
+    public static final String SUBJECT = "cloud-event-subject";
     /**
      * Metadata key to store the data content type.
      */
-    static final String DATA_CONTENT_TYPE = "cloud-event-data-content-type";
+    public static final String DATA_CONTENT_TYPE = "cloud-event-data-content-type";
     /**
      * Metadata key to store the data schema.
      */
-    static final String DATA_SCHEMA = "cloud-event-data-schema";
+    public static final String DATA_SCHEMA = "cloud-event-data-schema";
     private static final Set<String> RESERVED_METADATA = Stream
             .of(SUBJECT, DATA_CONTENT_TYPE, DATA_SCHEMA)
             .collect(Collectors.toCollection(HashSet::new));
@@ -60,11 +60,22 @@ public class MetadataUtils {
         // Utility class
     }
 
-    static Predicate<Map.Entry<String, Object>> reservedMetadataFilter() {
+    /**
+     * Provides a filter function which can be used to filter out the metadata keys used by this utility class.
+     *
+     * @return a predicate which can be applied on an entry of a metadata map
+     */
+    public static Predicate<Map.Entry<String, Object>> reservedMetadataFilter() {
         return e -> !RESERVED_METADATA.contains(e.getKey());
     }
 
-    static Map<String, Object> getAdditionalEntries(CloudEvent cloudEvent) {
+    /**
+     * If certain attributes are set on the {@link CloudEvent} these will be added with the correct metadata key.
+     *
+     * @param cloudEvent a {@link CloudEvent} to extract attributes.
+     * @return the map with metadata to add
+     */
+    public static Map<String, Object> getAdditionalEntries(CloudEvent cloudEvent) {
         Map<String, Object> metadataMap = new HashMap<>();
         if (!isNull(cloudEvent.getSubject())) {
             metadataMap.put(SUBJECT, cloudEvent.getSubject());
@@ -78,8 +89,13 @@ public class MetadataUtils {
         return metadataMap;
     }
 
+    /**
+     * Default function to set the subject to the value from the metadata with key {@link #SUBJECT} if present.
+     *
+     * @return a function to supply the subject based on a {@link EventMessage}
+     */
     @SuppressWarnings("squid:S1452") //needs wildcard to be generic
-    static Function<EventMessage<?>, Optional<String>> defaultSubjectSupplier() {
+    public static Function<EventMessage<?>, Optional<String>> defaultSubjectSupplier() {
         return message -> {
             Object subject = message.getMetaData().get(SUBJECT);
             if (subject instanceof String) {
@@ -90,8 +106,14 @@ public class MetadataUtils {
         };
     }
 
+    /**
+     * Default function to set the data content type to the value from the metadata with key {@link #DATA_CONTENT_TYPE}
+     * if present.
+     *
+     * @return a function to supply the data content type based on a {@link EventMessage}
+     */
     @SuppressWarnings("squid:S1452") //needs wildcard to be generic
-    static Function<EventMessage<?>, Optional<String>> defaultDataContentTypeSupplier() {
+    public static Function<EventMessage<?>, Optional<String>> defaultDataContentTypeSupplier() {
         return message -> {
             Object dataContentType = message.getMetaData().get(DATA_CONTENT_TYPE);
             if (dataContentType instanceof String) {
@@ -102,8 +124,13 @@ public class MetadataUtils {
         };
     }
 
+    /**
+     * Default function to set the data schema to the value from the metadata with key {@link #DATA_SCHEMA} if present.
+     *
+     * @return a function to supply the data schema based on a {@link EventMessage}
+     */
     @SuppressWarnings("squid:S1452") //needs wildcard to be generic
-    static Function<EventMessage<?>, Optional<URI>> defaultDataSchemaSupplier() {
+    public static Function<EventMessage<?>, Optional<URI>> defaultDataSchemaSupplier() {
         return message -> {
             Object dataSchema = message.getMetaData().get(DATA_SCHEMA);
             if (dataSchema instanceof URI) {

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverterTest.java
@@ -121,6 +121,13 @@ class CloudEventKafkaMessageConverterTest {
     }
 
     @Test
+    void whenNoSourceSupplierSet_thenSourceShouldBeAxonIQ() {
+        ProducerRecord<String, CloudEvent> evt = testSubject.createKafkaMessage(eventMessage(), SOME_TOPIC);
+
+        assertEquals(URI.create("https://www.axoniq.io/"), evt.value().getSource());
+    }
+
+    @Test
     void whenNoDataContentTypeSupplierSet_thenDataTypeShouldBeNull() {
         ProducerRecord<String, CloudEvent> evt = testSubject.createKafkaMessage(eventMessage(), SOME_TOPIC);
 
@@ -164,10 +171,14 @@ class CloudEventKafkaMessageConverterTest {
     }
 
     @Test
-    void whenReadingMessageMissingAxonHeader_thenShouldReturnMessageAnyway() {
-        ConsumerRecord<String, CloudEvent> msgWithoutHeaders =
+    void whenMinimalCloudEventRead_thenShouldReturnAxonMessageAnywayBasedOnDefaults() {
+        ConsumerRecord<String, CloudEvent> consumerRecord =
                 new ConsumerRecord<>("foo", 0, 0, "abc", minimalCloudEvent());
-        assertTrue(testSubject.readKafkaMessage(msgWithoutHeaders).isPresent());
+        EventMessage<?> eventMessage = testSubject.readKafkaMessage(consumerRecord).orElseThrow(
+                () -> new AssertionError("Expected valid message")
+        );
+        assertNotNull(eventMessage);
+        assertEquals(0, eventMessage.getMetaData().keySet().size());
     }
 
     @Test


### PR DESCRIPTION
Having a cloud event serializer would make it easier to use this extension when there is an existing Kafka cluster used, where the chosen format on the wire is Cloud Events. For example to build a projection combining 'external' events from Kafka with 'internal' events from Axon Server, or to send certain events to Kafka for 'external' use.

Some things left to do

- [x] Support mapping metadata key to extension name conversion, extension names can only use lowercase letters and digits. My idea is to add an optional String, String map to the builder, to do the conversion.
- [x] Add autowire support, when the Cloudevent serializer is used, when should also change the Kafka config so the correct Kafka Serializer and Deserializer are used.

Optionally:

- [x] Add an example project using cloud events, or add to the current one.
- ~~[ ] Have a better way to deal with unsupported metadata like lists.~~