### PR TITLE
Memory leak during Kafka subscription retry

### DIFF
--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/subscribable/SubscribableKafkaMessageSource.java
@@ -191,6 +191,7 @@ public class SubscribableKafkaMessageSource<K, V> implements SubscribableMessage
 
     private void restartOnError(RuntimeException e) {
         logger.warn("Consumer had a fatal exception, starting a new one", e);
+        fetcherRegistrations.removeIf(Registration::cancel); //retrying and keeping failed items in the list will cause memory leak
         addConsumer();
     }
 


### PR DESCRIPTION
addConsumer method in SubscribableKafkaMessageSource tries to add kafka consumer and invokes a runtimeErrorHandler in case of an exception. The class has a list - fetcherRegistrations - which keeps a list of all such registrations.
In case of an exception such as permission issues it keeps retrying and the list keeps growing causing memory leak.
This change clears the closed registrations from the list before retrying to stop the memory leak. Note: Registrations will always be closed in case of an exception(in finally block).

