### PR TITLE
use unique topics to avoid "marked for deletion error"

### DIFF
--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
@@ -135,7 +135,7 @@ class FetchEventsTaskTest {
 
 
         assertWithin(Duration.ofMillis(TIMEOUT_MILLIS), () -> assertTrue(expectedToBeClosed.get()));
-        verify(testConsumer).close();
+        verify(testConsumer, timeout(TIMEOUT_MILLIS)).close();
     }
 
     @Test


### PR DESCRIPTION
@smcvb I noticed this test failing after merging my changes. In [ConsumerPositionsUtilIntegrationTest.java's](https://github.com/AxonFramework/extension-kafka/pull/426/files#diff-13980d2dbc4e9f5b5aa671f53c1e2b6c6600db0ba9f565f03fc9524390bec3eb) tearDown method we were deleting the topic, however Kafka won't actually delete the topic right away, it just marks it for deletion. This change provides a unique topic per test, to just avoid the issue entirely.