### PR TITLE
Add ability to customize Kafka Event Publisher Processing Group name via properties

### DIFF
--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
+
 /**
  * Configuration properties for Axon for Apache Kafka.
  * <p>
@@ -227,6 +229,11 @@ public class KafkaProperties {
          */
         private ConfirmationMode confirmationMode = ConfirmationMode.NONE;
 
+        /**
+         * The Kafka Event Handler processing group. Defaults to {@code "__axon-kafka-event-publishing-group"}
+         */
+        private String processingGroup = DEFAULT_PROCESSING_GROUP;
+
         public boolean isEnabled() {
             return enabled;
         }
@@ -241,6 +248,14 @@ public class KafkaProperties {
 
         public void setConfirmationMode(ConfirmationMode confirmationMode) {
             this.confirmationMode = confirmationMode;
+        }
+
+        public String getProcessingGroup() {
+            return processingGroup;
+        }
+
+        public void setProcessingGroup(String processingGroup) {
+            this.processingGroup = processingGroup;
         }
     }
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
@@ -44,6 +44,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
     public static final String DEFAULT_PROCESSING_GROUP = "__axon-kafka-event-publishing-group";
     private static final boolean DOES_NOT_SUPPORT_RESET = false;
 
+    private final String processingGroup;
     private final KafkaPublisher<K, V> kafkaPublisher;
 
     /**
@@ -69,6 +70,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
      */
     protected KafkaEventPublisher(Builder<K, V> builder) {
         builder.validate();
+        this.processingGroup = builder.processingGroup != null ? builder.processingGroup : DEFAULT_PROCESSING_GROUP;
         this.kafkaPublisher = builder.kafkaPublisher;
     }
 
@@ -84,6 +86,14 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
     }
 
     /**
+     * Returns configured Processing Group name
+     * @return Processing Group name
+     */
+    public String getProcessingGroup() {
+        return this.processingGroup;
+    }
+
+    /**
      * Builder class to instantiate a {@link KafkaEventPublisher}.
      * <p>
      * The {@link KafkaPublisher} is a <b>hard requirements</b> and as such should be provided.
@@ -93,7 +103,21 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
      */
     public static class Builder<K, V> {
 
+        private String processingGroup;
         private KafkaPublisher<K, V> kafkaPublisher;
+
+        /**
+         * Sets the Kafka Event Handler processing group to be used by this {@link EventMessageHandler}
+         *
+         * @param processingGroup the Kafka Event Handler processing group to be used by this
+         *                        {@link EventMessageHandler}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<K, V> processingGroup(String processingGroup) {
+            assertNonNull(processingGroup, "ProcessingGroup may not be null");
+            this.processingGroup = processingGroup;
+            return this;
+        }
 
         /**
          * Sets the {@link KafkaPublisher} to be used by this {@link EventMessageHandler} to publish {@link

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
@@ -20,6 +20,7 @@ import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.eventhandling.EventMessage;
 import org.axonframework.eventhandling.EventMessageHandler;
 
+import static org.axonframework.common.BuilderUtils.assertNonEmpty;
 import static org.axonframework.common.BuilderUtils.assertNonNull;
 
 /**
@@ -70,7 +71,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
      */
     protected KafkaEventPublisher(Builder<K, V> builder) {
         builder.validate();
-        this.processingGroup = builder.processingGroup != null ? builder.processingGroup : DEFAULT_PROCESSING_GROUP;
+        this.processingGroup = builder.processingGroup;
         this.kafkaPublisher = builder.kafkaPublisher;
     }
 
@@ -103,7 +104,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
      */
     public static class Builder<K, V> {
 
-        private String processingGroup;
+        private String processingGroup = DEFAULT_PROCESSING_GROUP;
         private KafkaPublisher<K, V> kafkaPublisher;
 
         /**
@@ -114,7 +115,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
          * @return the current Builder instance, for fluent interfacing
          */
         public Builder<K, V> processingGroup(String processingGroup) {
-            assertNonNull(processingGroup, "ProcessingGroup may not be null");
+            assertNonEmpty(processingGroup, "ProcessingGroup may not be null or empty");
             this.processingGroup = processingGroup;
             return this;
         }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherIntegrationTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaPublisherIntegrationTest.java
@@ -412,11 +412,11 @@ class KafkaPublisherIntegrationTest extends KafkaContainerTest {
                 .registerEventHandler(config -> kafkaEventPublisher)
 
                 .registerListenerInvocationErrorHandler(
-                        DEFAULT_PROCESSING_GROUP, config -> PropagatingErrorHandler.instance()
+                        kafkaEventPublisher.getProcessingGroup(), config -> PropagatingErrorHandler.instance()
                 )
-                .registerSubscribingEventProcessor(DEFAULT_PROCESSING_GROUP)
+                .registerSubscribingEventProcessor(kafkaEventPublisher.getProcessingGroup())
                 .assignHandlerInstancesMatching(
-                        DEFAULT_PROCESSING_GROUP,
+                        kafkaEventPublisher.getProcessingGroup(),
                         eventHandler -> eventHandler.getClass().equals(KafkaEventPublisher.class)
                 )
         ).start();


### PR DESCRIPTION
When using Kafka Token Store with common topic for storing tokens from many applications the ability to distinguish processing groups from each application is needed. This can be done by manually configure `KafkaEventPublisher` with a lot of code. This PR adds ability to specify processing group name via properties.