### PR TITLE
Add ability to customize Kafka Event Publisher supportsReset flag via properties

### DIFF
--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/KafkaProperties.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DEFAULT_PROCESSING_GROUP;
+import static org.axonframework.extensions.kafka.eventhandling.producer.KafkaEventPublisher.DOES_NOT_SUPPORT_RESET;
 
 /**
  * Configuration properties for Axon for Apache Kafka.
@@ -234,6 +235,11 @@ public class KafkaProperties {
          */
         private String processingGroup = DEFAULT_PROCESSING_GROUP;
 
+        /**
+         * If true the Kafka Event Handler will support reset and replay. Defaults to {@code false}
+         */
+        private boolean supportsReset = DOES_NOT_SUPPORT_RESET;
+
         public boolean isEnabled() {
             return enabled;
         }
@@ -256,6 +262,14 @@ public class KafkaProperties {
 
         public void setProcessingGroup(String processingGroup) {
             this.processingGroup = processingGroup;
+        }
+
+        public boolean isSupportsReset() {
+            return supportsReset;
+        }
+
+        public void setSupportsReset(boolean supportsReset) {
+            this.supportsReset = supportsReset;
         }
     }
 

--- a/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
+++ b/kafka-spring-boot-autoconfigure/src/main/java/org/axonframework/extensions/kafka/autoconfig/KafkaAutoConfiguration.java
@@ -191,6 +191,7 @@ public class KafkaAutoConfiguration {
         KafkaEventPublisher<K, V> kafkaEventPublisher = KafkaEventPublisher
                 .<K, V>builder()
                 .processingGroup(properties.getPublisher().getProcessingGroup())
+                .supportsReset(properties.getPublisher().isSupportsReset())
                 .kafkaPublisher(kafkaPublisher)
                 .build();
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/producer/KafkaEventPublisher.java
@@ -43,9 +43,10 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
      * {@link KafkaEventPublisher}.
      */
     public static final String DEFAULT_PROCESSING_GROUP = "__axon-kafka-event-publishing-group";
-    private static final boolean DOES_NOT_SUPPORT_RESET = false;
+    public static final boolean DOES_NOT_SUPPORT_RESET = false;
 
     private final String processingGroup;
+    private final boolean supportsReset;
     private final KafkaPublisher<K, V> kafkaPublisher;
 
     /**
@@ -72,6 +73,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
     protected KafkaEventPublisher(Builder<K, V> builder) {
         builder.validate();
         this.processingGroup = builder.processingGroup;
+        this.supportsReset = builder.supportsReset;
         this.kafkaPublisher = builder.kafkaPublisher;
     }
 
@@ -83,7 +85,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
 
     @Override
     public boolean supportsReset() {
-        return DOES_NOT_SUPPORT_RESET;
+        return this.supportsReset;
     }
 
     /**
@@ -105,6 +107,7 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
     public static class Builder<K, V> {
 
         private String processingGroup = DEFAULT_PROCESSING_GROUP;
+        private boolean supportsReset = DOES_NOT_SUPPORT_RESET;
         private KafkaPublisher<K, V> kafkaPublisher;
 
         /**
@@ -117,6 +120,18 @@ public class KafkaEventPublisher<K, V> implements EventMessageHandler {
         public Builder<K, V> processingGroup(String processingGroup) {
             assertNonEmpty(processingGroup, "ProcessingGroup may not be null or empty");
             this.processingGroup = processingGroup;
+            return this;
+        }
+
+        /**
+         * Sets the Kafka Event Handler supports reset flag to be used by this {@link EventMessageHandler}
+         *
+         * @param supportsReset the Kafka Event Handler supports reset flag to be used by this
+         *                      {@link EventMessageHandler}
+         * @return the current Builder instance, for fluent interfacing
+         */
+        public Builder<K, V> supportsReset(boolean supportsReset) {
+            this.supportsReset = supportsReset;
             return this;
         }
 


### PR DESCRIPTION
By default the Kafka Event Publisher doesn't support reset and this is not configurable at all. This PR adds ability to customise this via builder and Spring Boot configuration properties.