### PR TITLE
CloudEventKafkaMessageConverter when converting to CloudEvent can ignore metadata keys that are not valid extension names

### DIFF
--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverterTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/cloudevent/CloudEventKafkaMessageConverterTest.java
@@ -290,6 +290,22 @@ class CloudEventKafkaMessageConverterTest {
     }
 
     @Test
+    void whenMetadataContainsWrongName_thenIgnoreIt() {
+        testSubject = CloudEventKafkaMessageConverter.builder()
+                .serializer(serializer)
+                .ignoreInvalidExtensionNames(true)
+                .build();
+
+        EventMessage<Object> eventMessage =
+                asEventMessage("SomePayload").withMetaData(MetaData.with("_KEY", "value").and("key", "foo"));
+
+        ProducerRecord<String, CloudEvent> senderMessage = testSubject.createKafkaMessage(eventMessage, SOME_TOPIC);
+
+        assertEquals("foo", senderMessage.value().getExtension("key"));
+        assertNull(senderMessage.value().getExtension("_KEY"));
+    }
+
+    @Test
     void whenMetadataContainsUnsupportedValue_thenThrowAnError() {
         EventMessage<Object> eventMessage = asEventMessage("SomePayload")
                 .withMetaData(MetaData.with("key", Collections.singletonList("value")));


### PR DESCRIPTION
This PR adds an ability to ignore metadata keys that are not valid extension names when converting to `CloudEvent` thus not throwing `InvalidMetaDataException`. Warn message is logged instead of exception.