### PR TITLE
[#555] Add option to commit offsets

### DIFF
--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/AsyncFetcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,10 +94,10 @@ public class AsyncFetcher<K, V, E> implements Fetcher<K, V, E> {
      */
     @Override
     public Registration poll(Consumer<K, V> consumer,
-                             RecordConverter<K, V, E> recordConverter,
-                             EventConsumer<E> eventConsumer) {
+            RecordConverter<K, V, E> recordConverter,
+            EventConsumer<E> eventConsumer) {
         return poll(consumer, recordConverter, eventConsumer,
-                    e -> logger.warn("Error from fetching thread, should be handled properly", e));
+                e -> logger.warn("Error from fetching thread, should be handled properly", e));
     }
 
     /**
@@ -105,15 +105,15 @@ public class AsyncFetcher<K, V, E> implements Fetcher<K, V, E> {
      */
     @Override
     public Registration poll(Consumer<K, V> consumer, RecordConverter<K, V, E> recordConverter,
-                             EventConsumer<E> eventConsumer, RuntimeErrorHandler runtimeErrorHandler) {
+            EventConsumer<E> eventConsumer, RuntimeErrorHandler runtimeErrorHandler) {
         FetchEventsTask<K, V, E> fetcherTask =
                 new FetchEventsTask<>(consumer,
-                                      pollTimeout,
-                                      recordConverter,
-                                      eventConsumer,
-                                      activeFetchers::remove,
-                                      runtimeErrorHandler,
-                                      offsetCommitType);
+                        pollTimeout,
+                        recordConverter,
+                        eventConsumer,
+                        activeFetchers::remove,
+                        runtimeErrorHandler,
+                        offsetCommitType);
 
         activeFetchers.add(fetcherTask);
         executorService.execute(fetcherTask);
@@ -162,22 +162,32 @@ public class AsyncFetcher<K, V, E> implements Fetcher<K, V, E> {
          */
         public Builder<K, V, E> pollTimeout(long timeoutMillis) {
             assertThat(timeoutMillis, timeout -> timeout > 0,
-                       "The poll timeout may not be negative [" + timeoutMillis + "]");
+                    "The poll timeout may not be negative [" + timeoutMillis + "]");
             this.pollTimeout = Duration.ofMillis(timeoutMillis);
             return this;
         }
 
         /**
-         * Set the {@code offsetCommitType}, options are:
-         * {@link OffsetCommitType#AUTO} let the Kafka consumer commit offsets automatically in background
-         * {@link OffsetCommitType#COMMIT_SYNC} let the Kafka consumer commit offsets synchronously after processing
-         * {@link OffsetCommitType#COMMIT_ASYNC} let the Kafka consumer commit offsets asynchronously after processing
-         * Defaults to {@code OffsetCommitType#AUTO}
+         * Sets the {@code offsetCommitType} defining how the {@link FetchEventsTask} will commit offsets during
+         * processing of events.
+         * <p>
+         * Options are:
+         * <ul>
+         *     <li>{@link OffsetCommitType#AUTO} - let the Kafka consumer commit offsets automatically in background.
+         *     </li>
+         *     <li>{@link OffsetCommitType#COMMIT_SYNC} - let the Kafka consumer commit offsets synchronously after
+         *     processing.</li>
+         *     <li>{@link OffsetCommitType#COMMIT_ASYNC} - let the Kafka consumer commit offsets asynchronously after
+         *     processing.</li>
+         * </ul>
+         * <p>
+         * Defaults to {@code OffsetCommitType#AUTO}, meaning the offset commit task happens in the background.
          *
          * @param offsetCommitType {@link OffsetCommitType} enum to specify the offset commit type
          * @return the current Builder instance, for fluent interfacing
          */
         public AsyncFetcher.Builder<K, V, E> offsetCommitType(OffsetCommitType offsetCommitType) {
+            assertNonNull(offsetCommitType, "OffsetCommitType may not be null");
             this.offsetCommitType = offsetCommitType;
             return this;
         }

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTask.java
@@ -52,7 +52,7 @@ class FetchEventsTask<K, V, E> implements Runnable {
     private final EventConsumer<E> eventConsumer;
     private final java.util.function.Consumer<FetchEventsTask<K, V, E>> closeHandler;
     private final RuntimeErrorHandler runtimeErrorHandler;
-    private final boolean commitOnProcessed;
+    private final OffsetCommitType offsetCommitType;
 
 
     /**
@@ -74,7 +74,7 @@ class FetchEventsTask<K, V, E> implements Runnable {
                     EventConsumer<E> eventConsumer,
                     java.util.function.Consumer<FetchEventsTask<K, V, E>> closeHandler,
                     RuntimeErrorHandler runtimeErrorHandler,
-                    boolean commitOnProcessed) {
+                    OffsetCommitType offsetCommitType) {
         this.consumer = nonNull(consumer, () -> "Consumer may not be null");
         assertThat(pollTimeout, time -> !time.isNegative(),
                    "The poll timeout may not be negative [" + pollTimeout + "]");
@@ -83,7 +83,7 @@ class FetchEventsTask<K, V, E> implements Runnable {
         this.eventConsumer = eventConsumer;
         this.closeHandler = getOrDefault(closeHandler, task -> { /* no-op */ });
         this.runtimeErrorHandler = nonNull(runtimeErrorHandler, () -> "Runtime error handler may not be null");
-        this.commitOnProcessed = commitOnProcessed;
+        this.offsetCommitType = offsetCommitType;
     }
 
     @Override
@@ -112,15 +112,24 @@ class FetchEventsTask<K, V, E> implements Runnable {
         try {
             if (!convertedMessages.isEmpty()) {
                 eventConsumer.consume(convertedMessages);
-                if (commitOnProcessed) {
-                    consumer.commitSync();
-                    logger.debug("Committed offsets after processing {} messages", convertedMessages.size());
-                }
+                handleOffsetsIfRequired(convertedMessages.size());
             }
         } catch (InterruptedException e) {
             logger.debug("Event Consumer thread was interrupted. Shutting down", e);
             running.set(false);
             Thread.currentThread().interrupt();
+        }
+    }
+
+    private void handleOffsetsIfRequired(int messageCount) {
+        if (OffsetCommitType.COMMIT_SYNC == offsetCommitType) {
+            consumer.commitSync();
+            logger.debug("Committed offsets synchronously for {} messages", messageCount);
+        } else if (OffsetCommitType.COMMIT_ASYNC == offsetCommitType) {
+            consumer.commitAsync();
+            logger.debug("Committed offsets asynchronously for {} messages", messageCount);
+        } else {
+            logger.debug("Consumer will commit offsets in background");
         }
     }
 

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/OffsetCommitType.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/OffsetCommitType.java
@@ -1,0 +1,10 @@
+package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+/**
+ * Enum to define how the consumer will handle committing offsets.
+ */
+public enum OffsetCommitType {
+    AUTO,
+    COMMIT_ASYNC,
+    COMMIT_SYNC
+}

--- a/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/OffsetCommitType.java
+++ b/kafka/src/main/java/org/axonframework/extensions/kafka/eventhandling/consumer/OffsetCommitType.java
@@ -1,10 +1,47 @@
+/*
+ * Copyright (c) 2010-2025. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.axonframework.extensions.kafka.eventhandling.consumer;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 /**
  * Enum to define how the consumer will handle committing offsets.
+ *
+ * @author Bradley Skuse
+ * @since 4.11.1
  */
 public enum OffsetCommitType {
+
+    /**
+     * Kafka consumer will commit offsets automatically in the background.
+     */
     AUTO,
+
+    /**
+     * Kafka consumer will commit offsets asynchronously after processing
+     *
+     * @see KafkaConsumer#commitAsync()
+     */
     COMMIT_ASYNC,
+
+    /**
+     * Kafka consumer will commit offsets synchronously after processing
+     *
+     * @see KafkaConsumer#commitSync()
+     */
     COMMIT_SYNC
 }

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2022. Axon Framework
+ * Copyright (c) 2010-2025. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
+++ b/kafka/src/test/java/org/axonframework/extensions/kafka/eventhandling/consumer/FetchEventsTaskTest.java
@@ -76,7 +76,8 @@ class FetchEventsTaskTest {
                 testRecordConverter,
                 testEventConsumer,
                 testCloseHandler,
-                runtimeErrorHandler
+                runtimeErrorHandler,
+                false
         );
 
         when(testConsumer.poll(testPollTimeout)).thenReturn(consumerRecords);
@@ -95,7 +96,8 @@ class FetchEventsTaskTest {
                         testRecordConverter,
                         testEventConsumer,
                         testCloseHandler,
-                        runtimeErrorHandler
+                        runtimeErrorHandler,
+                        false
                 )
         );
     }
@@ -111,7 +113,8 @@ class FetchEventsTaskTest {
                         testRecordConverter,
                         testEventConsumer,
                         testCloseHandler,
-                        runtimeErrorHandler
+                        runtimeErrorHandler,
+                        false
                 )
         );
     }
@@ -127,7 +130,8 @@ class FetchEventsTaskTest {
                 testRecordConverter,
                 failingEventConsumer,
                 testCloseHandler,
-                runtimeErrorHandler
+                runtimeErrorHandler,
+                false
         );
 
         Thread taskRunner = new Thread(testSubjectWithFailingEventConsumer);
@@ -148,6 +152,7 @@ class FetchEventsTaskTest {
         verify(testConsumer, atLeastOnceWithTimeout).poll(testPollTimeout);
         verify(testRecordConverter, atLeastOnceWithTimeout).convert(consumerRecords);
         verify(testEventConsumer, atLeastOnceWithTimeout).consume(Collections.singletonList(kafkaEventMessage));
+        verify(testConsumer, never()).commitSync();
 
         taskRunner.interrupt();
     }
@@ -163,6 +168,7 @@ class FetchEventsTaskTest {
         verify(testConsumer, atLeastOnceWithTimeout).poll(testPollTimeout);
         verify(testRecordConverter, atLeastOnceWithTimeout).convert(consumerRecords);
         verifyNoMoreInteractions(testEventConsumer);
+        verify(testConsumer, never()).commitSync();
 
         taskRunner.interrupt();
     }
@@ -176,5 +182,30 @@ class FetchEventsTaskTest {
 
         assertWithin(Duration.ofMillis(TIMEOUT_MILLIS), () -> assertTrue(expectedToBeClosed.get()));
         verify(testConsumer, timeout(TIMEOUT_MILLIS)).close();
+    }
+
+    @Test
+    void testFetchEventsTaskPollsConvertsAndConsumesRecordsAndCommitOffsets() throws InterruptedException {
+        VerificationMode atLeastOnceWithTimeout = timeout(TIMEOUT_MILLIS).atLeastOnce();
+
+        FetchEventsTask<String, String, KafkaEventMessage> testSubjectWithCommitOffsets = new FetchEventsTask<>(
+                testConsumer,
+                testPollTimeout,
+                testRecordConverter,
+                testEventConsumer,
+                testCloseHandler,
+                runtimeErrorHandler,
+                true
+        );
+
+        Thread taskRunner = new Thread(testSubjectWithCommitOffsets);
+        taskRunner.start();
+
+        verify(testConsumer, atLeastOnceWithTimeout).poll(testPollTimeout);
+        verify(testRecordConverter, atLeastOnceWithTimeout).convert(consumerRecords);
+        verify(testEventConsumer, atLeastOnceWithTimeout).consume(Collections.singletonList(kafkaEventMessage));
+        verify(testConsumer, atLeastOnceWithTimeout).commitSync();
+
+        taskRunner.interrupt();
     }
 }


### PR DESCRIPTION
Resolves #555 

This adds an option so that offsets can be committed after processing of events, instead of using enable auto commit.

Edit: Added ability to use auto, async or sync 